### PR TITLE
Add failure_message to reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # sauce-cypress-runner
 Sauce Labs test runner image to run Cypress tests on Sauce.
+
+## Usage
+
+### Build Docker Image
+`make docker`

--- a/src/custom-reporter.js
+++ b/src/custom-reporter.js
@@ -289,7 +289,10 @@ MochaJUnitReporter.prototype.getSauceTestcaseData = function (testcase) {
     between_commands: testcase.duration,
     result: {
       status: testcase.state,
-      failure_reason: null
+      failure_reason: JSON.stringify({
+        'message': testcase.err && testcase.err.message,
+        'stack': testcase.err && testcase.err.stack
+      })
     },
     request: {
       body: testcase.body


### PR DESCRIPTION
Add error message and error stack to the "failure_message".

Also got the ball rolling on README.md, just added the instruction on how to build the docker image.