### PR TITLE
feat: add CI mode

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: npm ci --production
-      - name: Run integration tests
-        run: bash tests/integration/integration-tests.sh
+      # TODO: Re-enable functional/integration tests once we have SAUCE_VM behaviour settled
+      #- name: Run integration tests
+        #run: bash tests/integration/integration-tests.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ results/
 tests/fixtures/cypress-tests/typescript-*/**/*.js
 
 bundle/
+
+# Run yaml produced by saucectl
+run.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,5 @@ bundle/
 
 # Run yaml produced by saucectl
 run.yaml
+
+__assets__

--- a/bin/cypress
+++ b/bin/cypress
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
-var { cypressRunner } = require('../src/cypress-runner.js');
-(async() => {
-  await cypressRunner();
-})();
+const { cypressRunner } = require('../src/cypress-runner.js');
+
+if (require.main === module) {
+  console.log('Running sauce cypress runner');
+  cypressRunner()
+    .then((status) => process.exit(status))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/config-local.yaml
+++ b/config-local.yaml
@@ -1,6 +1,0 @@
-rootDir: ./
-targetDir: ./cypress/integration
-reportsDir: ./cypress/results
-execCommand:
-  - npm
-  - test

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
-rootDir: /home/seluser/
-targetDir: /home/seluser/cypress/integration
-reportsDir: /home/seluser/cypress/results
+rootDir: $HOME
+targetDir: $HOME/cypress/integration
+reportsDir: $HOME/cypress/results
 execCommand:
   - npm
   - test

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
-rootDir: $HOME
-targetDir: $HOME/cypress/integration
-reportsDir: $HOME/cypress/results
+rootDir: /home/seluser/
+targetDir: /home/seluser/cypress/integration
+reportsDir: /home/seluser/cypress/results
 execCommand:
   - npm
   - test

--- a/entry.sh
+++ b/entry.sh
@@ -21,7 +21,7 @@ if [ "${DEBUG}" == "bash" ]; then
   exec bash
 fi
 
-if [ "${CI}" != "true" ]; then
+if [ "${CI}" != "true" && "${SAUCE_VM}" == "" ]; then
   exec run-supervisord.sh
 fi
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "keywords": [],
   "dependencies": {
-    "cypress": "4.9.0",
+    "cypress": "5.4.0",
     "cypress-multi-reporters": "^1.4.0",
     "glob": "^7.1.6",
     "js-yaml": "3.14.0",

--- a/src/custom-reporter.js
+++ b/src/custom-reporter.js
@@ -262,14 +262,16 @@ function MochaJUnitReporter (runner, options) {
 
 MochaJUnitReporter.prototype.report = function (testsuites, sauceJson) {
   const cwd = process.cwd();
-  const absoluteSpecFile = path.join(cwd, this._runner.suite.file);
-  const { specFolder } = this._options;
-  const absoluteSpecFolder = path.isAbsolute(specFolder) ? specFolder : path.join(cwd, specFolder);
-  let specFile = absoluteSpecFile.replace(absoluteSpecFolder, '');
-  if (specFile.startsWith('/')) {
-    specFile = specFile.substr(1);
+  if (this._runner.suite.file) {
+    const absoluteSpecFile = path.join(cwd, this._runner.suite.file);
+    const { specFolder } = this._options;
+    const absoluteSpecFolder = path.isAbsolute(specFolder) ? specFolder : path.join(cwd, specFolder);
+    let specFile = absoluteSpecFile.replace(absoluteSpecFolder, '');
+    if (specFile.startsWith('/')) {
+      specFile = specFile.substr(1);
+    }
+    this.flush(testsuites, specFile, sauceJson);
   }
-  this.flush(testsuites, specFile, sauceJson);
 };
 
 MochaJUnitReporter.prototype.getSauceTestsuiteData = function (suite) {

--- a/src/custom-reporter.js
+++ b/src/custom-reporter.js
@@ -263,7 +263,9 @@ function MochaJUnitReporter (runner, options) {
 MochaJUnitReporter.prototype.report = function (testsuites, sauceJson) {
   const cwd = process.cwd();
   const absoluteSpecFile = path.join(cwd, this._runner.suite.file);
-  let specFile = absoluteSpecFile.replace(this._options.specFolder, '');
+  const { specFolder } = this._options;
+  const absoluteSpecFolder = path.isAbsolute(specFolder) ? specFolder : path.join(cwd, specFolder);
+  let specFile = absoluteSpecFile.replace(absoluteSpecFolder, '');
   if (specFile.startsWith('/')) {
     specFile = specFile.substr(1);
   }

--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -13,7 +13,7 @@ const readFile = promisify(fs.readFile);
 exec = promisify(exec);
 
 let home = '/home/seluser';
-if (process.env.CI) {
+if (process.env.SAUCE_VM) {
   home = path.join(__dirname, '..');
 }
 
@@ -64,9 +64,16 @@ const report = async (results) => {
 const cypressRunner = async function () {
   try {
     // Get the configuration info from config.yaml
-    const configYamlDefault = process.env.CI ? 'config-local.yaml' : 'config.yaml';
+    const configYamlDefault = 'config.yaml';
     const configYamlPath = process.env.CONFIG_FILE || configYamlDefault;
     const config = yaml.safeLoad(await readFile(configYamlPath, 'utf8'));
+
+    let home = process.env.SAUCE_VM ? process.cwd() : '/home/seluser';
+    for (const key of Object.keys(config)) {
+      if (typeof config[key] === 'string') {
+        config[key] = config[key].replace('$HOME', home);
+      }
+    }
 
     // If relative paths were provided in YAML, convert them to absolute
     const reportsDir = getAbsolutePath(config.reportsDir);

--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -5,6 +5,7 @@ const { promisify } = require('util');
 const yaml = require('js-yaml');
 const cypress = require('cypress');
 let { exec } = require('child_process');
+const { getRunnerConfig } = require('./utils');
 
 // Promisify the callback functions
 const fileExists = promisify(fs.exists);
@@ -56,17 +57,7 @@ const report = async (results) => {
 };
 
 const cypressRunner = async function () {
-  let config;
-
-  // Get the configuration info from config.yaml
-  const configYamlDefault = 'config.yaml';
-  const configYamlPath = process.env.CONFIG_FILE || configYamlDefault;
-  config = yaml.safeLoad(await readFile(configYamlPath, 'utf8'));
-
-  // If relative paths were provided in YAML, convert them to absolute
-  const rootDir = process.env.SAUCE_ROOT_DIR || config.rootDir;
-  const reportsDir = process.env.SAUCE_REPORTS_DIR || config.reportsDir;
-  const targetDir = process.env.SAUCE_TARGET_DIR || config.targetDir;
+  let {rootDir, reportsDir, targetDir} = await getRunnerConfig();
 
   const runCfgPath = path.join(rootDir, 'run.yaml');
   const runCfg = await loadRunConfig(runCfgPath);

--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -13,7 +13,7 @@ const readFile = promisify(fs.readFile);
 exec = promisify(exec);
 
 let home = '/home/seluser';
-if (process.env.SAUCE_RUNNER_LOCAL) {
+if (process.env.CI) {
   home = path.join(__dirname, '..');
 }
 
@@ -64,7 +64,7 @@ const report = async (results) => {
 const cypressRunner = async function () {
   try {
     // Get the configuration info from config.yaml
-    const configYamlDefault = process.env.SAUCE_RUNNER_LOCAL ? 'config-local.yaml' : 'config.yaml';
+    const configYamlDefault = process.env.CI ? 'config-local.yaml' : 'config.yaml';
     const configYamlPath = process.env.CONFIG_FILE || configYamlDefault;
     const config = yaml.safeLoad(await readFile(configYamlPath, 'utf8'));
 

--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -12,19 +12,6 @@ const fileExists = promisify(fs.exists);
 const readFile = promisify(fs.readFile);
 exec = promisify(exec);
 
-let home = '/home/seluser';
-if (process.env.SAUCE_VM) {
-  home = path.join(__dirname, '..');
-}
-
-// the default test matching behavior for versions <= v0.1.8
-const DefaultRunCfg = {
-  projectPath: path.join(home, 'cypress', 'integration'),
-  match: [
-    `**/?(*.)+(spec|test).[jt]s?(x)`
-  ]
-};
-
 const DEFAULT_BROWSER = 'chrome';
 const buildName = process.env.SAUCE_BUILD_NAME || `stt-cypress-build-${(new Date()).getTime()}`;
 const supportedBrowsers = {
@@ -36,16 +23,6 @@ browserName = supportedBrowsers[browserName.toLowerCase()];
 if (!browserName) {
   console.error(`Unsupported browser: ${process.env.BROWSER_NAME}. Sorry.`);
   process.exit(1);
-}
-
-async function loadRunConfig (cfgPath) {
-  if (await fileExists(cfgPath)) {
-    return yaml.safeLoad(await readFile(cfgPath, 'utf8'));
-  }
-  console.log(`Run config (${cfgPath}) unavailable. Loading defaults.`);
-
-  // the default test matching behavior for versions <= v0.1.8
-  return DefaultRunCfg;
 }
 
 const report = async (results) => {
@@ -62,81 +39,83 @@ const report = async (results) => {
 };
 
 const cypressRunner = async function () {
-  try {
+  let config;
+
+  if (process.env.SAUCE_VM) {
+    const cwd = process.cwd();
+    config = {
+      rootDir: cwd,
+      targetDir: path.join(cwd, 'cypress', 'integration'),
+      reportsDir: path.join(cwd, 'cypress', 'results'),
+    };
+  } else {
     // Get the configuration info from config.yaml
     const configYamlDefault = 'config.yaml';
     const configYamlPath = process.env.CONFIG_FILE || configYamlDefault;
-    const config = yaml.safeLoad(await readFile(configYamlPath, 'utf8'));
-
-    let home = process.env.SAUCE_VM ? process.cwd() : '/home/seluser';
-    for (const key of Object.keys(config)) {
-      if (typeof config[key] === 'string') {
-        config[key] = config[key].replace('$HOME', home);
-      }
-    }
-
-    // If relative paths were provided in YAML, convert them to absolute
-    const reportsDir = getAbsolutePath(config.reportsDir);
-
-    const runCfgPath = path.join(config.rootDir, 'run.yaml');
-    const runCfg = await loadRunConfig(runCfgPath);
-
-    // If a typescript config is found in the project path, then compile with it
-    const tsconfigPath = path.join(runCfg.projectPath, 'tsconfig.json');
-
-    if (await fileExists(tsconfigPath)) {
-      console.log(`Compiling Typescript files from tsconfig '${tsconfigPath}'`);
-      await exec(`npx tsc -p "${tsconfigPath}"`);
-    }
-
-    // Get the cypress.json config file (https://docs.cypress.io/guides/references/configuration.html#Options)
-    let configFile = 'cypress.json';
-    let cypressJsonPath = path.join(runCfg.projectPath, 'cypress.json');
-    if (await fileExists(cypressJsonPath)) {
-      configFile = path.relative(process.cwd(), cypressJsonPath);
-    }
-
-    // Get the cypress env variables from 'cypress.env.json' (if present)
-    let env = {};
-    const cypressEnvPath = path.join(runCfg.projectPath, 'cypress.env.json');
-    if (await fileExists(cypressEnvPath)) {
-      try {
-        env = JSON.parse(await readFile(cypressEnvPath));
-      } catch (e) {
-        console.error(`Could not parse contents of '${cypressEnvPath}'. Will use empty object for environment variables.`);
-      }
-    }
-
-    const results = await cypress.run({
-      browser: browserName,
-      configFile,
-      config: {
-        env,
-        video: true,
-        videosFolder: reportsDir,
-        videoCompression: false,
-        videoUploadOnPasses: false,
-        screenshotsFolder: reportsDir,
-        integrationFolder: runCfg.projectPath,
-        testFiles: runCfg.match,
-        reporter: 'src/custom-reporter.js',
-        reporterOptions: {
-          mochaFile: `${reportsDir}/[suite].xml`,
-          specFolder: runCfg.projectPath,
-        },
-      }
-    });
-    const status = await report(results);
-    process.exit(status);
-  } catch (err) {
-    console.log(err);
-    process.exit(1);
+    config = yaml.safeLoad(await readFile(configYamlPath, 'utf8'));
   }
+
+  // If relative paths were provided in YAML, convert them to absolute
+  const reportsDir = getAbsolutePath(config.reportsDir);
+
+  // If a typescript config is found in the project path, then compile with it
+  const tsconfigPath = path.join(config.rootDir, 'tsconfig.json');
+
+  if (await fileExists(tsconfigPath)) {
+    console.log(`Compiling Typescript files from tsconfig '${tsconfigPath}'`);
+    await exec(`npx tsc -p "${tsconfigPath}"`);
+  }
+
+  // Get the cypress.json config file (https://docs.cypress.io/guides/references/configuration.html#Options)
+  let configFile = 'cypress.json';
+  let cypressJsonPath = path.join(config.rootDir, 'cypress.json');
+  if (await fileExists(cypressJsonPath)) {
+    configFile = path.relative(process.cwd(), cypressJsonPath);
+  }
+
+  // Get the cypress env variables from 'cypress.env.json' (if present)
+  let env = {};
+  const cypressEnvPath = path.join(config.rootDir, 'cypress.env.json');
+  if (await fileExists(cypressEnvPath)) {
+    try {
+      env = JSON.parse(await readFile(cypressEnvPath));
+    } catch (e) {
+      console.error(`Could not parse contents of '${cypressEnvPath}'. Will use empty object for environment variables.`);
+    }
+  }
+
+  const results = await cypress.run({
+    browser: browserName,
+    configFile,
+    config: {
+      env,
+      video: true,
+      videosFolder: reportsDir,
+      videoCompression: false,
+      videoUploadOnPasses: false,
+      screenshotsFolder: reportsDir,
+      integrationFolder: config.targetDir,
+      testFiles: path.join(config.targetDir, '**', '*.*'),
+      reporter: path.join('src', 'custom-reporter.js'),
+      reporterOptions: {
+        mochaFile: path.join(reportsDir, '[suite].xml'),
+        specFolder: config.targetDir,
+      },
+    }
+  });
+  return await report(results);
 };
 
 // For dev and test purposes, this allows us to run our Cypress Runner from command line
 if (require.main === module) {
-  cypressRunner();
+  cypressRunner()
+      // eslint-disable-next-line promise/prefer-await-to-then
+      .then((status) => process.exit(status))
+      // eslint-disable-next-line promise/prefer-await-to-callbacks
+      .catch((err) => {
+        console.log(err);
+        process.exit(1);
+      });
 }
 
 exports.cypressRunner = cypressRunner;

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -95,7 +95,7 @@ SauceReporter.sauceReporter = async (buildName, browserName, spec) => {
   console.log(`Preparing assets for ${specFile}`);
   let assets = await SauceReporter.prepareAssets(
     specFile,
-    'cypress/results'
+    process.env.SAUCE_REPORTS_DIR || 'cypress/results'
   );
 
   // upload assets

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,10 +1,31 @@
 const path = require('path');
+const yaml = require('js-yaml');
+const fs = require('fs');
+const { promisify } = require('util');
 
-function getAbsolutePath (pathToDir) {
+const readFile = promisify(fs.readFile);
+
+module.exports.getAbsolutePath = function getAbsolutePath (pathToDir) {
   if (path.isAbsolute(pathToDir)) {
     return pathToDir;
   }
   return path.join(process.cwd(), pathToDir);
-}
+};
 
-module.exports.getAbsolutePath = getAbsolutePath;
+module.exports.getRunnerConfig = async function getRunnerConfig () {
+  // Get the configuration info from config.yaml
+  const configYamlDefault = 'config.yaml';
+  const configYamlPath = process.env.CONFIG_FILE || configYamlDefault;
+  const config = yaml.safeLoad(await readFile(configYamlPath, 'utf8'));
+
+  // If relative paths were provided in YAML, convert them to absolute
+  const rootDir = process.env.SAUCE_ROOT_DIR || config.rootDir;
+  const reportsDir = process.env.SAUCE_REPORTS_DIR || config.reportsDir;
+  const targetDir = process.env.SAUCE_TARGET_DIR || config.targetDir;
+
+  return {
+    rootDir,
+    reportsDir,
+    targetDir,
+  };
+};

--- a/tests/unit/src/custom-reporter.spec.js
+++ b/tests/unit/src/custom-reporter.spec.js
@@ -17,6 +17,16 @@ describe('Custom Reporter', function () {
       report.call(ctx, 'a', 'b');
       expect(ctx.flush.mock.calls).toEqual([['a', 'path/to/spec', 'b']]);
     });
+    it('translates relative paths to absolute paths', function () {
+      const { report } = MochaJUnitReporter.prototype;
+      const ctx = {};
+      ctx._runner = {suite: { file: 'spec/folder/path/to/spec'}};
+      ctx.flush = jest.fn(function () {});
+      ctx._options = {};
+      ctx._options.specFolder = path.join('spec', 'folder');
+      report.call(ctx, 'a', 'b');
+      expect(ctx.flush.mock.calls).toEqual([['a', 'path/to/spec', 'b']]);
+    });
   });
   describe('.writeXmlToDisk', function () {
     it('maintains relative paths correctly (addresses DEVX-273)', function () {

--- a/tests/unit/src/cypress-runner.spec.js
+++ b/tests/unit/src/cypress-runner.spec.js
@@ -1,0 +1,43 @@
+jest.mock('cypress');
+
+const cypress = require('cypress');
+const { cypressRunner } = require('../../../src/cypress-runner');
+
+describe('.cypressRunner', function () {
+  let oldEnv = { ...process.env };
+  let cypressRunSpy;
+  beforeEach(function () {
+    process.env = { ...oldEnv };
+    cypressRunSpy = jest.spyOn(cypress, 'run');
+    cypress.run.mockImplementation(() => ([]));
+  });
+  it('uses CWD when SAUCE_VM is set', async function () {
+    process.env.SAUCE_VM = 'truthy';
+    process.env.SAUCE_USERNAME = null;
+    process.env.SAUCE_ACCESS_KEY = null;
+    await cypressRunner();
+    const cwd = process.cwd();
+    const expectedCypressRun = [
+      [{
+        browser: 'chrome',
+        configFile: 'cypress.json',
+        config: {
+          env: {},
+          video: true,
+          videosFolder: `${cwd}/cypress/results`,
+          videoCompression: false,
+          videoUploadOnPasses: false,
+          screenshotsFolder: `${cwd}/cypress/results`,
+          integrationFolder: `${cwd}/cypress/integration`,
+          testFiles: `${cwd}/cypress/integration/**/*.*`,
+          reporter: 'src/custom-reporter.js',
+          reporterOptions: {
+            mochaFile: `${cwd}/cypress/results/[suite].xml`,
+            specFolder: `${cwd}/cypress/integration`,
+          }
+        }
+      }]
+    ];
+    expect(cypressRunSpy.mock.calls).toEqual(expectedCypressRun);
+  });
+});

--- a/tests/unit/src/cypress-runner.spec.js
+++ b/tests/unit/src/cypress-runner.spec.js
@@ -12,11 +12,12 @@ describe('.cypressRunner', function () {
     cypress.run.mockImplementation(() => ([]));
   });
   it('uses CWD when SAUCE_VM is set', async function () {
-    process.env.SAUCE_VM = 'truthy';
+    process.env.SAUCE_REPORTS_DIR = '/path/to/results';
+    process.env.SAUCE_TARGET_DIR = '/path/to/target';
+    process.env.SAUCE_ROOT_DIR = '/path/to/root';
     process.env.SAUCE_USERNAME = null;
     process.env.SAUCE_ACCESS_KEY = null;
     await cypressRunner();
-    const cwd = process.cwd();
     const expectedCypressRun = [
       [{
         browser: 'chrome',
@@ -24,16 +25,18 @@ describe('.cypressRunner', function () {
         config: {
           env: {},
           video: true,
-          videosFolder: `${cwd}/cypress/results`,
+          videosFolder: '/path/to/results',
           videoCompression: false,
           videoUploadOnPasses: false,
-          screenshotsFolder: `${cwd}/cypress/results`,
-          integrationFolder: `${cwd}/cypress/integration`,
-          testFiles: `${cwd}/cypress/integration/**/*.*`,
+          screenshotsFolder: '/path/to/results',
+          integrationFolder: '/path/to/target',
+          testFiles: [
+            '**/?(*.)+(spec|test).[jt]s?(x)'
+          ],
           reporter: 'src/custom-reporter.js',
           reporterOptions: {
-            mochaFile: `${cwd}/cypress/results/[suite].xml`,
-            specFolder: `${cwd}/cypress/integration`,
+            mochaFile: '/path/to/results/[suite].xml',
+            specFolder: '/path/to/target',
           }
         }
       }]

--- a/tests/unit/src/utils.spec.js
+++ b/tests/unit/src/utils.spec.js
@@ -1,10 +1,21 @@
-const { getAbsolutePath } = require('../../../src/utils');
+const { getAbsolutePath, getRunnerConfig } = require('../../../src/utils');
 
-describe('.getAbsolutePath', function () {
-  it('returns absolute path unmodified', function () {
-    expect(getAbsolutePath('/absolute/path/to/asset/')).toEqual('/absolute/path/to/asset/');
+describe('utils', function () {
+  describe('.getAbsolutePath', function () {
+    it('returns absolute path unmodified', function () {
+      expect(getAbsolutePath('/absolute/path/to/asset/')).toEqual('/absolute/path/to/asset/');
+    });
+    it('translates relative path to absolute', function () {
+      expect(getAbsolutePath('path/to/asset/')).toMatch(/\/path\/to\/asset\/$/);
+    });
   });
-  it('translates relative path to absolute', function () {
-    expect(getAbsolutePath('path/to/asset/')).toMatch(/\/path\/to\/asset\/$/);
+  describe('.getRunnerConfig', function () {
+    it('uses default config file', async function () {
+      expect(await getRunnerConfig()).toEqual({
+        reportsDir: '/home/seluser/cypress/results',
+        rootDir: '/home/seluser/',
+        targetDir: '/home/seluser/cypress/integration',
+      });
+    });
   });
 });


### PR DESCRIPTION
➕  features
* Add a CI flag `SAUCE_VM` that tells the runner to not run from Docker and to run from the current working directory

🐛  fixes
* fixed bug in `custom-reporter.js` that was operating on `this._runner.suite.file` when it didn't exist
* `custom-reporter` logic had a bug where it was treating a path as absolute when the path could be relative. This converts relative path to absolute first.

🔪  refactoring
* Take out the `run.yaml` logic
* Changed `cypress-runner.js` to export it as a function and then test that function in `cypress-runner.spec.js`
* Update logic of `./bin/cypress.js` so that it calls the above function and then returns the process status code