### PR TITLE
enhancements: Package a template project 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,5 @@ Dockerfile
 .git
 .gitignore
 .sauce
+.saucetpl
 cypress

--- a/.github/workflows/helpers/print-release-id.js
+++ b/.github/workflows/helpers/print-release-id.js
@@ -1,22 +1,37 @@
-const axios = require('axios');
+
+const { get } = require('https');
 
 /**
  * Get the release associated with a tag and print the release ID to console
  * @param {string} tag 
  */
-async function printReleaseId (tag) {
-    const url = `https://api.github.com/repos/saucelabs/sauce-cypress-runner/releases/tags/${tag}`;
-    const res = await axios.get(url);
-    console.log(res.data.id);
-};
+const printReleaseId = (repo, tag) => new Promise(async (resolve) => {
+  get(`https://api.github.com/repos/${repo}/releases/tags/${tag}`, {
+    headers: {
+      'Accept': 'application/vnd.github.v3+json',
+      'User-Agent': 'ReleaseId Fetcher',
+    }
+  }, (res) => {
+    let body = '';
+    res.on('data', (chunk) => {
+      body += chunk;
+    });
+    res.on('end', () => {
+      body = JSON.parse(body);
+      console.log(body.id);
+      resolve();
+    });
+  });
+});
 
 if (require.main === module) {
+  let repo = process.env.GH_REPO;
   let ref = process.env.GH_REF;
-  let [,type,value] = ref.split('/');
-  if (type != 'tag') {
-    value = 'v0.1.9'; // <-- for testing purposes
+  let [,type,tag] = ref.split('/');
+  if (!['tag', 'tags'].includes(type)) {
+    tag = 'v0.1.9'; // <-- for testing purposes
   }
-  printReleaseId(value)
+  printReleaseId(repo, tag)
     .then(() => process.exit(0))
     .catch(() => process.exit(1));
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,24 @@ on:
     tags:
       - 'v*.*.*'
 jobs:  
+  release-github:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare
+        id: prep
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          echo ::set-output name=version::${VERSION}
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.prep.outputs.version }}
+          release_name: Release ${{ steps.prep.outputs.version }}
+          body: Release ${{ steps.prep.outputs.version }}
+          draft: false
   release-docker:
     runs-on: ubuntu-latest
     steps:
@@ -40,6 +58,7 @@ jobs:
             saucelabs/stt-cypress-mocha-node:${{ steps.prep.outputs.version }}
   release-windows-bundle:
     runs-on: windows-latest
+    needs: release-github
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -78,25 +97,39 @@ jobs:
           asset_content_type: application/zip
   release-template-bundle:
     runs-on: ubuntu-latest
+    needs: release-github
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Use Node.js v14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
       - name: Prepare
         id: prep
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
           echo ::set-output name=version::${VERSION}
+      - name: Get release ID
+        id: get_release_id
+        run: |
+          echo "::set-output name=release_id::$(node ./.github/workflows/helpers/print-release-id.js)"
+        env:
+          GH_REF: ${{ github.ref }}
+          GH_REPO: ${{ github.repository }}
+      - name: Print release id
+        run: echo ${{ steps.get_release_id.outputs.release_id }}
       - name: Update Release version
-        run: sed -i "s/##VERSION##/${{ steps.prep.outputs.version }}/g" .saucetpl/.sauce/config.yaml
+        run: sed -i "s/##VERSION##/${{ steps.prep.outputs.version }}/g" .saucetpl/.sauce/config.yml
       - name: Archive template
-        run: tar --strip-components 1 -czf saucetpl.tar.gz .saucetpl
+        run: cd .saucetpl && tar -czf ../saucetpl.tar.gz .
       - name: Upload Template Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: https://uploads.github.com/repos/saucelabs/sauce-cypress-runner/releases/${{ steps.prep.outputs.version }}/assets?name=saucetpl.tar.gz
+          upload_url: https://uploads.github.com/repos/saucelabs/sauce-cypress-runner/releases/${{ steps.get_release_id.outputs.release_id }}/assets?name=saucetpl.tar.gz
           asset_path: ./saucetpl.tar.gz
           asset_name: saucetpl.tar.gz
           asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,19 +81,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Use Node.js v14.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-      - run: npm install
-      - name: Get release ID
-        id: get_release_id
+      - name: Prepare
+        id: prep
         run: |
-          echo "::set-output name=release_id::$(node ./.github/workflows/helpers/print-release-id.js)"
-        env:
-          GH_REF: ${{ github.ref }}
+          VERSION=${GITHUB_REF#refs/tags/}
+          echo ::set-output name=version::${VERSION}
       - name: Update Release version
-        run: sed -i "s/##VERSION##/${{ steps.get_release_id.outputs.release_id }}/g" .saucetpl/.sauce/config.yaml
+        run: sed -i "s/##VERSION##/${{ steps.prep.outputs.version }}/g" .saucetpl/.sauce/config.yaml
       - name: Archive template
         run: tar --strip-components 1 -czf saucetpl.tar.gz .saucetpl
       - name: Upload Template Asset
@@ -102,7 +96,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: https://uploads.github.com/repos/saucelabs/sauce-cypress-runner/releases/${{ steps.get_release_id.outputs.release_id }}/assets?name=saucetpl.tar.gz
+          upload_url: https://uploads.github.com/repos/saucelabs/sauce-cypress-runner/releases/${{ steps.prep.outputs.version }}/assets?name=saucetpl.tar.gz
           asset_path: ./saucetpl.tar.gz
           asset_name: saucetpl.tar.gz
           asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,33 @@ jobs:
           asset_path: ./sauce-cypress-win.zip
           asset_name: sauce-cypress-win.zip
           asset_content_type: application/zip
+  release-template-bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js v14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - run: npm install
+      - name: Get release ID
+        id: get_release_id
+        run: |
+          echo "::set-output name=release_id::$(node ./.github/workflows/helpers/print-release-id.js)"
+        env:
+          GH_REF: ${{ github.ref }}
+      - name: Update Release version
+        run: sed -i "s/##VERSION##/${{ steps.get_release_id.outputs.release_id }}/g" .saucetpl/.sauce/config.yaml
+      - name: Archive template
+        run: tar --strip-components 1 -czf saucetpl.tar.gz .saucetpl
+      - name: Upload Template Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: https://uploads.github.com/repos/saucelabs/sauce-cypress-runner/releases/${{ steps.get_release_id.outputs.release_id }}/assets?name=saucetpl.tar.gz
+          asset_path: ./saucetpl.tar.gz
+          asset_name: saucetpl.tar.gz
+          asset_content_type: application/tar+gzip

--- a/.gitignore
+++ b/.gitignore
@@ -107,7 +107,7 @@ dist
 /cypress/
 
 # saucectl configuration folder
-.sauce
+/.sauce
 
 results/
 

--- a/.saucetpl/.sauce/config.yml
+++ b/.saucetpl/.sauce/config.yml
@@ -1,0 +1,18 @@
+apiVersion: v1alpha
+metadata:
+  name: Feature XYZ
+  tags:
+    - e2e
+    - release team
+    - other tag
+  build: Release $CI_COMMIT_SHORT_SHA
+files:
+  - cypress/integration/example.test.js
+suites:
+  - name: "saucy test"
+    match: ".*.(spec|test).js$"
+image:
+  base: saucelabs/stt-cypress-mocha-node
+  version: ##VERSION##
+sauce:
+  region: us-west-1

--- a/.saucetpl/cypress/integration/example.test.js
+++ b/.saucetpl/cypress/integration/example.test.js
@@ -1,0 +1,10 @@
+context('Actions', () => {
+    beforeEach(() => {
+        cy.visit('https://example.cypress.io/commands/actions')
+    })
+    it('.type() - type into a DOM element', () => {
+        // https://on.cypress.io/type
+        cy.get('.action-email')
+            .type('fake@email.com').should('have.value', 'fake@email.com')
+    })
+})


### PR DESCRIPTION
## Proposed changes

This PR adds (during release process) the generation of a **[saucectl](https://github.com/saucelabs/saucectl)** template to be used when initiating a new project.

It will add, to each release, a `saucetpl.tar.gz` that will contains:
- Default configuration for this runner
- An example file

Elements can be added simply by adding files/contents into the `.saucetpl` folder.

It also make `.github/workflows/helpers/print-release-id.js` repo agnostic and with no dependencies required.