### PR TITLE
fix: Inject repo reference while building windows artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
           echo "::set-output name=release_id::$(node ./.github/workflows/helpers/print-release-id.js)"
         env:
           GH_REF: ${{ github.ref }}
+          GH_REPO: ${{ github.repository }}
       - name: Print release id
         run: echo ${{ steps.get_release_id.outputs.release_id }}
       - name: Bundle Directory


### PR DESCRIPTION
The update of the scripts extracting the release_id required the GH_REPO to be set on.
Currently it is not, and prevent the windows artifact to be produced.