### PR TITLE
add SAUCE_BROWSER_PATH option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ This env variable is for controlling cypress native video recording.
 saucectl run -e SAUCE_CYPRESS_VIDEO_RECORDING=true
 ```
 
+### `BROWSER_NAME`
+Name of the browser to run the test on
+
+#### `SAUCE_BROWSER_PATH`
+Points to the browser binary path
+
 ## Publishing to Docker Hub
 To publish the Docker image:
 * Create a [new release](https://github.com/saucelabs/sauce-cypress-runner/releases)

--- a/tests/unit/src/cypress-runner.spec.js
+++ b/tests/unit/src/cypress-runner.spec.js
@@ -59,6 +59,8 @@ describe('.cypressRunner', function () {
     expect(calledBrowser).toEqual('C:/User/App/browser.exe:chrome');
   });
   it('calls sauce reporter and returns a job status', async function () {
+    process.env.SAUCE_USERNAME = 'bruno.alassia';
+    process.env.SAUCE_ACCESS_KEY = 'i_l0ve_mayonnaise';
     process.env.SAUCE_BUILD_NAME = 'fake-build-name';
     process.env.BROWSER_NAME = 'firefox';
     sauceReporter.mockClear();

--- a/tests/unit/src/cypress-runner.spec.js
+++ b/tests/unit/src/cypress-runner.spec.js
@@ -13,7 +13,6 @@ describe('.cypressRunner', function () {
     jest.resetModules();
     process.env = { ...oldEnv };
     cypressRunSpy.mockClear();
-    sauceReporter.mockClear();
     const cypressRunResults = {
       runs: ['spec-a', 'spec-b'],
       failures: [],
@@ -62,6 +61,7 @@ describe('.cypressRunner', function () {
   it('calls sauce reporter and returns a job status', async function () {
     process.env.SAUCE_BUILD_NAME = 'fake-build-name';
     process.env.BROWSER_NAME = 'firefox';
+    sauceReporter.mockClear();
     await cypressRunner();
     expect(sauceReporter.mock.calls).toEqual([
       ['fake-build-name', 'firefox', 'spec-a'],

--- a/tests/unit/src/cypress-runner.spec.js
+++ b/tests/unit/src/cypress-runner.spec.js
@@ -1,15 +1,24 @@
 jest.mock('cypress');
+jest.mock('../../../src/sauce-reporter');
 
 const cypress = require('cypress');
+const { sauceReporter } = require('../../../src/sauce-reporter');
 const { cypressRunner } = require('../../../src/cypress-runner');
 
 describe('.cypressRunner', function () {
   let oldEnv = { ...process.env };
   let cypressRunSpy;
+  cypressRunSpy = jest.spyOn(cypress, 'run');
   beforeEach(function () {
+    jest.resetModules();
     process.env = { ...oldEnv };
-    cypressRunSpy = jest.spyOn(cypress, 'run');
-    cypress.run.mockImplementation(() => ([]));
+    cypressRunSpy.mockClear();
+    sauceReporter.mockClear();
+    const cypressRunResults = {
+      runs: ['spec-a', 'spec-b'],
+      failures: [],
+    };
+    cypress.run.mockImplementation(() => cypressRunResults);
   });
   it('can hardcode locations of reports, target and root', async function () {
     process.env.SAUCE_REPORTS_DIR = '/path/to/results';
@@ -42,5 +51,27 @@ describe('.cypressRunner', function () {
       }]
     ];
     expect(cypressRunSpy.mock.calls).toEqual(expectedCypressRun);
+  });
+  it('can hardcode the browser path', async function () {
+    process.env.BROWSER_NAME = 'chrome';
+    process.env.SAUCE_BROWSER_PATH = 'C:/User/App/browser.exe';
+    await cypressRunner();
+    const calledBrowser = cypressRunSpy.mock.calls[0][0].browser;
+    expect(calledBrowser).toEqual('C:/User/App/browser.exe:chrome');
+  });
+  it('calls sauce reporter and returns a job status', async function () {
+    process.env.SAUCE_BUILD_NAME = 'fake-build-name';
+    process.env.BROWSER_NAME = 'firefox';
+    await cypressRunner();
+    expect(sauceReporter.mock.calls).toEqual([
+      ['fake-build-name', 'firefox', 'spec-a'],
+      ['fake-build-name', 'firefox', 'spec-b'],
+    ]);
+  });
+  it('throws error if browser is unsupported', function () {
+    process.env.BROWSER_NAME = 'lynx';
+    expect(cypressRunner()).rejects.toThrow(new Error(
+      `Unsupported browser: 'lynx'. Sorry.`
+    ));
   });
 });


### PR DESCRIPTION
* This PR adds a variable called `SAUCE_BROWSER_PATH` that, when set, tells Cypress to run on that path
* This, along with `BROWSER_NAME`, gets passed to Cypress.run in the form `browser="C:/path/to/browser.exe:chrome"`

Other:
* Added some more tests to further solidify cypress-runner
* Moved `BROWSER_NAME` and `BUILD_NAME` variables to the inside of functions so that they can be unit tested