### PR TITLE
Create one job that covers all specs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5030,6 +5030,16 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
+    "fluent-ffmpeg": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.2.tgz",
+      "integrity": "sha1-yVLeIkD4EuvaCqgAbXd27irPfXQ=",
+      "dev": true,
+      "requires": {
+        "async": ">=0.2.9",
+        "which": "^1.1.1"
+      }
+    },
     "follow-redirects": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5034,7 +5034,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.2.tgz",
       "integrity": "sha1-yVLeIkD4EuvaCqgAbXd27irPfXQ=",
-      "dev": true,
       "requires": {
         "async": ">=0.2.9",
         "which": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "mocha-junit-reporter": "^2.0.0",
     "saucelabs": "^4.5.0",
     "typescript": "^3.9.7",
-    "webdriverio": "6.1.22"
+    "webdriverio": "6.1.22",
+    "fluent-ffmpeg": "2.1.2"
   },
   "devDependencies": {
     "@types/chai": "^4.2.12",
@@ -39,8 +40,7 @@
     "husky": "^4.3.0",
     "jest": "^26.4.2",
     "mocha": "^8.1.3",
-    "typescript": "^3.9.7",
-    "fluent-ffmpeg": "2.1.2"
+    "typescript": "^3.9.7"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "husky": "^4.3.0",
     "jest": "^26.4.2",
     "mocha": "^8.1.3",
-    "typescript": "^3.9.7"
+    "typescript": "^3.9.7",
+    "fluent-ffmpeg": "2.1.2"
   },
   "husky": {
     "hooks": {

--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -42,10 +42,10 @@ const report = async (results, browserName) => {
     return status;
   }
   const runs = results.runs || [];
+
   const buildName = process.env.SAUCE_BUILD_NAME || `stt-cypress-build-${(new Date()).getTime()}`;
-  for (let spec of runs) {
-    await sauceReporter(buildName, browserName, spec);
-  }
+  await sauceReporter(buildName, browserName, runs, status);
+
   return status;
 };
 

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -62,7 +62,6 @@ SauceReporter.prepareAssets = async (specFiles, resultsFolder) => {
 
   if (videos.length !== 0) {
     let comboVideo = path.join(resultsFolder, 'video.mp4');
-    console.info(`Combining videos ${videos}`);
     await SauceReporter.mergeVideos(videos, comboVideo);
     assets.push(comboVideo);
   }
@@ -71,8 +70,8 @@ SauceReporter.prepareAssets = async (specFiles, resultsFolder) => {
 };
 
 SauceReporter.sauceReporter = async (buildName, browserName, testruns, failures) => {
-  // TODO take test name from saucectl
-  let testName = `devx cypress - full suite`;
+  // SAUCE_JOB_NAME is only available for saucectl >= 0.16, hence the fallback
+  let testName = process.env.SAUCE_JOB_NAME | `DevX Cypress Test Run - ${(new Date()).getTime()}`;
   let tags = process.env.SAUCE_TAGS;
 
   const api = new SauceLabs({
@@ -179,7 +178,6 @@ SauceReporter.mergeVideos = function (videos, target) {
           reject();
         })
         .on('end', function () {
-          console.log('Finished merging videos!');
           resolve();
         })
         .mergeToFile(target, os.tmpdir());

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -71,7 +71,7 @@ SauceReporter.prepareAssets = async (specFiles, resultsFolder) => {
 
 SauceReporter.sauceReporter = async (buildName, browserName, testruns, failures) => {
   // SAUCE_JOB_NAME is only available for saucectl >= 0.16, hence the fallback
-  let testName = process.env.SAUCE_JOB_NAME | `DevX Cypress Test Run - ${(new Date()).getTime()}`;
+  let testName = process.env.SAUCE_JOB_NAME || `DevX Cypress Test Run - ${(new Date()).getTime()}`;
   let tags = process.env.SAUCE_TAGS;
 
   const api = new SauceLabs({

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -32,17 +32,19 @@ SauceReporter.prepareAssets = async (specFiles, resultsFolder) => {
   const assets = [];
   const videos = [];
 
-  for (let specFile of specFiles) {
-    // Copy global log as specFile cypress log
-    const {rootDir} = await getRunnerConfig();
-    fs.copyFileSync(path.join(rootDir, 'console.log'), path.join(resultsFolder, `${specFile}.log`));
+  // Add the main console log
+  const {rootDir} = await getRunnerConfig();
+  let clog = path.join(rootDir, 'console.log');
+  if (fs.existsSync(clog)) {
+    assets.push(clog);
+  }
 
+  for (let specFile of specFiles) {
     const tmpFolder = fs.mkdtempSync(path.join(os.tmpdir(), md5(specFile)));
     const specFilename = path.basename(specFile);
     const sauceAssets = [
       { name: `${specFilename}.mp4`, ext: 'mp4' },
       { name: `${specFilename}.json`, ext: 'json' },
-      { name: `${specFilename}.log`, ext: 'log' },
       { name: `${specFilename}.xml`, ext: 'xml' },
     ];
 

--- a/tests/unit/src/cypress-runner.spec.js
+++ b/tests/unit/src/cypress-runner.spec.js
@@ -66,8 +66,7 @@ describe('.cypressRunner', function () {
     sauceReporter.mockClear();
     await cypressRunner();
     expect(sauceReporter.mock.calls).toEqual([
-      ['fake-build-name', 'firefox', 'spec-a'],
-      ['fake-build-name', 'firefox', 'spec-b'],
+      ['fake-build-name', 'firefox', ['spec-a', 'spec-b'], []],
     ]);
   });
   it('throws error if browser is unsupported', function () {

--- a/tests/unit/src/sauce-reporter.spec.js
+++ b/tests/unit/src/sauce-reporter.spec.js
@@ -28,12 +28,14 @@ describe('SauceReporter', function () {
       fs.copyFileSync.mockReturnValue(true);
       fs.mkdtempSync.mockReturnValue('tmp/folder');
       utils.getRunnerConfig.mockReturnValue({reportsDir: '/fake/reports/dir/', rootDir: '/fake/root/dir/'});
-      const res = await SauceReporter.prepareAssets('spec/file', 'results/');
+      SauceReporter.mergeVideos = jest.fn().mockImplementation(async function () {});
+      const res = await SauceReporter.prepareAssets(['spec/file.test.js'], 'results/');
       expect(res).toEqual([
-        'tmp/folder/video.mp4',
-        'tmp/folder/log.json',
+        'tmp/folder/file.test.js.mp4',
+        'tmp/folder/file.test.js.json',
+        'tmp/folder/file.test.js.xml',
         'tmp/folder/console.log',
-        'tmp/folder/junit.xml'
+        'results/video.mp4'
       ]);
     });
     it('should return an empty list of assets if files not found (addresses DEVX-273)', async function () {
@@ -63,9 +65,9 @@ describe('SauceReporter', function () {
     });
     it('should call uploadJobAssets on SauceLabs api', async function () {
       prepareAssetsSpy.mockReturnValue(['asset/one', 'asset/two']);
-      await SauceReporter.sauceReporter('build', 'browser', {
+      await SauceReporter.sauceReporter('build', 'browser', [{
         spec: {name: 'MySpec'}, stats: {failures: 0}
-      });
+      }], 0);
       expect(uploadJobAssetsSpy.mock.calls).toEqual([
         ['a', {'files': ['asset/one', 'asset/two']}]
       ]);

--- a/tests/unit/src/sauce-reporter.spec.js
+++ b/tests/unit/src/sauce-reporter.spec.js
@@ -75,9 +75,9 @@ describe('SauceReporter', function () {
     it('should output err when upload failed', async function () {
       let originalConsole = console.error;
       prepareAssetsSpy.mockReturnValue(['asset/one', 'asset/two']);
-      await SauceReporter.sauceReporter('build', 'browser', {
+      await SauceReporter.sauceReporter('build', 'browser', [{
         spec: {name: 'MySpec'}, stats: {failures: 0}
-      });
+      }]);
 
       let consoleOutput = [];
       const mockErr = output => consoleOutput.push(output);

--- a/tests/unit/src/sauce-reporter.spec.js
+++ b/tests/unit/src/sauce-reporter.spec.js
@@ -31,10 +31,10 @@ describe('SauceReporter', function () {
       SauceReporter.mergeVideos = jest.fn().mockImplementation(async function () {});
       const res = await SauceReporter.prepareAssets(['spec/file.test.js'], 'results/');
       expect(res).toEqual([
+        '/fake/root/dir/console.log',
         'tmp/folder/file.test.js.mp4',
         'tmp/folder/file.test.js.json',
         'tmp/folder/file.test.js.xml',
-        'tmp/folder/console.log',
         'results/video.mp4'
       ]);
     });


### PR DESCRIPTION
Before this change: Multiple Jobs are created (one Job per spec file)
After this change: Single Job is created (regardless of the number of spec files)

Individual reports are still created for each spec file and so are the videos. However, all videos are also merged into a single large one.

In this iteration (first out of two), the image still uses `run.yaml` to be told what to run, but will work on as many test file as are listed. In the second iteration (not this PR), we'll instead pass the native test matching parameter from saucectl to the image. This could be still done via `run.yaml` if so desired or perhaps simply via env vars.