### PR TITLE
fix: Save initial console.log not in reportsDir

### DIFF
--- a/src/cypress-recorder.js
+++ b/src/cypress-recorder.js
@@ -7,7 +7,8 @@ const { getRunnerConfig } = require('./utils');
 
 async function cypressRecorder () {
   const {reportsDir} = await getRunnerConfig();
-  const fd = fs.openSync(path.join(reportsDir, 'console.log'), 'w+', 0o644);
+  // console.log is saved out of reportsDir since it is cleared on startup.
+  const fd = fs.openSync(path.join(reportsDir, '..', 'console.log'), 'w+', 0o644);
   const ws = stream.Writable({
     write (data, encoding, cb) { fs.write(fd, data, undefined, encoding, cb); },
   });

--- a/src/cypress-recorder.js
+++ b/src/cypress-recorder.js
@@ -6,9 +6,9 @@ const child_process = require('child_process');
 const { getRunnerConfig } = require('./utils');
 
 async function cypressRecorder () {
-  const {reportsDir} = await getRunnerConfig();
+  const {rootDir} = await getRunnerConfig();
   // console.log is saved out of reportsDir since it is cleared on startup.
-  const fd = fs.openSync(path.join(reportsDir, '..', 'console.log'), 'w+', 0o644);
+  const fd = fs.openSync(path.join(rootDir, 'console.log'), 'w+', 0o644);
   const ws = stream.Writable({
     write (data, encoding, cb) { fs.write(fd, data, undefined, encoding, cb); },
   });

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -28,8 +28,8 @@ SauceReporter.prepareAsset = (specFile, resultsFolder, tmpFolder, ext, name) => 
 
 SauceReporter.prepareAssets = async (specFile, resultsFolder) => {
   // Copy global log as specFile cypress log
-  const {reportsDir} = await getRunnerConfig();
-  fs.copyFileSync(path.join(reportsDir, '..', 'console.log'), path.join(resultsFolder, `${specFile}.log`));
+  const {rootDir} = await getRunnerConfig();
+  fs.copyFileSync(path.join(rootDir, 'console.log'), path.join(resultsFolder, `${specFile}.log`));
 
   const tmpFolder = fs.mkdtempSync(path.join(os.tmpdir(), md5(specFile)));
   const sauceAssets = [

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -29,7 +29,7 @@ SauceReporter.prepareAsset = (specFile, resultsFolder, tmpFolder, ext, name) => 
 SauceReporter.prepareAssets = async (specFile, resultsFolder) => {
   // Copy global log as specFile cypress log
   const {reportsDir} = await getRunnerConfig();
-  fs.copyFileSync(path.join(reportsDir, 'console.log'), path.join(resultsFolder, `${specFile}.log`));
+  fs.copyFileSync(path.join(reportsDir, '..', 'console.log'), path.join(resultsFolder, `${specFile}.log`));
 
   const tmpFolder = fs.mkdtempSync(path.join(os.tmpdir(), md5(specFile)));
   const sauceAssets = [

--- a/tests/unit/src/sauce-reporter.spec.js
+++ b/tests/unit/src/sauce-reporter.spec.js
@@ -27,7 +27,7 @@ describe('SauceReporter', function () {
       fs.existsSync.mockReturnValue(true);
       fs.copyFileSync.mockReturnValue(true);
       fs.mkdtempSync.mockReturnValue('tmp/folder');
-      utils.getRunnerConfig.mockReturnValue({reportsDir: '/fake/reports/dir/'});
+      utils.getRunnerConfig.mockReturnValue({reportsDir: '/fake/reports/dir/', rootDir: '/fake/root/dir/'});
       const res = await SauceReporter.prepareAssets('spec/file', 'results/');
       expect(res).toEqual([
         'tmp/folder/video.mp4',
@@ -40,7 +40,7 @@ describe('SauceReporter', function () {
       fs.existsSync.mockReturnValue(false);
       fs.copyFileSync.mockReturnValue(true);
       fs.mkdtempSync.mockReturnValue('tmp/folder');
-      utils.getRunnerConfig.mockReturnValue({reportsDir: '/fake/reports/dir/'});
+      utils.getRunnerConfig.mockReturnValue({reportsDir: '/fake/reports/dir/', rootDir: '/fake/root/dir/'});
       const res = await SauceReporter.prepareAssets('spec/file', 'results/');
       expect(res).toEqual([]);
     });


### PR DESCRIPTION
## Proposed change

When starting a bunch of tests, `cypress` clear the `reportsDir` folder and so our clone of console that we are currently recording.
To avoid that, store the recording, one folder up prevents the assets exporter from failing.