### PR TITLE
fix: Ensure cypress exitCode is propagated up to saucectl

### DIFF
--- a/src/cypress-recorder.js
+++ b/src/cypress-recorder.js
@@ -21,10 +21,10 @@ async function cypressRecorder () {
   child.stdout.pipe(ws);
   child.stderr.pipe(ws);
 
-  child.on('exit', (exitCode) => ws.end(() => {
+  child.on('exit', (exitCode) => {
     fs.closeSync(fd);
     process.exit(exitCode);
-  }));
+  });
 }
 
 exports.cypressRecorder = cypressRecorder;


### PR DESCRIPTION
## Proposed changes

Restore expected `exitCode` to be non-zero when some tests are failing.
Relates: https://github.com/saucelabs/testrunner-toolkit/issues/63

![render1604425003079](https://user-images.githubusercontent.com/11074879/98021462-37f6ab80-1db9-11eb-8648-5e3a0c8e81a3.gif)

### Considerations

It's not optimum since `stream.Writable` is not cleanly closed before file being closed. As soon as operations are maid on stream either `ws.end()` or waiting for `stream.finished()`, `exitCode` resets to 0 and npm is not failing as expected.