### PR TITLE
Don't merge videos of different sizes

### DIFF
--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -174,8 +174,7 @@ SauceReporter.sauceReporter = async (buildName, browserName, testruns, failures)
 
 SauceReporter.mergeVideos = async (videos, target) => {
   if (!await SauceReporter.areVideosSameSize(videos)) {
-    console.log('Videos are not of the same size. Unable to merge.');
-    console.log(`Using ${videos[0]} as the main video.`);
+    console.log(`Videos are not of the same size. Unable to merge. Using ${videos[0]} as the main video.`);
     fs.copyFileSync(videos[0], target);
     return;
   }
@@ -201,8 +200,14 @@ SauceReporter.mergeVideos = async (videos, target) => {
 SauceReporter.areVideosSameSize = async (videos) => {
   let lastSize;
   for (let video of videos) {
-    let metadata = await ffprobe(video);
-    let vs = metadata.streams[0];
+    let metadata;
+    try {
+      metadata = await ffprobe(video);
+    } catch (e) {
+      console.error(`Failed to inspect video ${video}, it may be corrupt: `, e);
+      throw e;
+    }
+    let vs = metadata.streams.find(s => s.codec_type === 'video');
 
     if (!lastSize) {
       lastSize = {width: vs.width, height: vs.height};

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -173,8 +173,8 @@ SauceReporter.sauceReporter = async (buildName, browserName, testruns, failures)
 };
 
 SauceReporter.mergeVideos = async (videos, target) => {
-  if (!await SauceReporter.areVideosSameSize(videos)) {
-    console.log(`Videos are not of the same size. Unable to merge. Using ${videos[0]} as the main video.`);
+  if (videos.length === 1 || !await SauceReporter.areVideosSameSize(videos)) {
+    console.log(`Using ${videos[0]} as the main video.`);
     fs.copyFileSync(videos[0], target);
     return;
   }
@@ -213,6 +213,7 @@ SauceReporter.areVideosSameSize = async (videos) => {
       lastSize = {width: vs.width, height: vs.height};
     }
     if (lastSize.width !== vs.width || lastSize.height !== vs.height) {
+      console.log('Detected inconsistent video sizes.');
       return false;
     }
   }


### PR DESCRIPTION
When using Electron or Firefox, the videos are consistently the same size.
When using Chrome however, the first video tends to be a different size than all the other specs.
This behavior is irrespective of what image is being used and is replicable with cypress' own docker image as well.
So for the time being, if we detect that videos are of inconsistent size, we skip the video merge.