### PR TITLE
skip asset upload if sauce vm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4226,6 +4226,16 @@
       "requires": {
         "async": ">=0.2.9",
         "which": "^1.1.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "follow-redirects": {

--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -36,8 +36,6 @@ async function loadRunConfig (cfgPath) {
 }
 
 const report = async (results, browserName) => {
-  let status = 1;
-
   // Prepare the assets
   const runs = results.runs || [];
   const resultsFolder = process.env.SAUCE_REPORTS_DIR || 'cypress/results';
@@ -47,15 +45,17 @@ const report = async (results, browserName) => {
     resultsFolder,
   );
 
-  if (!process.env.SAUCE_VM) {
-    status = results.failures || results.totalFailed;
-    if (!(process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY)) {
-      console.log('Skipping asset uploads! Remember to setup your SAUCE_USERNAME/SAUCE_ACCESS_KEY');
-      return status;
-    }
-    const buildName = process.env.SAUCE_BUILD_NAME || `stt-cypress-build-${(new Date()).getTime()}`;
-    await sauceReporter(buildName, browserName, assets, status);
+  if (process.env.SAUCE_VM) {
+    return 1;
   }
+
+  let status = results.failures || results.totalFailed;
+  if (!(process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY)) {
+    console.log('Skipping asset uploads! Remember to setup your SAUCE_USERNAME/SAUCE_ACCESS_KEY');
+    return status;
+  }
+  const buildName = process.env.SAUCE_BUILD_NAME || `stt-cypress-build-${(new Date()).getTime()}`;
+  await sauceReporter(buildName, browserName, assets, status);
 
   return status;
 };

--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -46,7 +46,7 @@ const report = async (results, browserName) => {
   );
 
   if (process.env.SAUCE_VM) {
-    return 1;
+    return 0;
   }
 
   let status = results.failures || results.totalFailed;

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -75,7 +75,7 @@ SauceReporter.prepareAssets = async (specFiles, resultsFolder) => {
   return assets;
 };
 
-SauceReporter.sauceReporter = async (buildName, browserName, testruns, failures) => {
+SauceReporter.sauceReporter = async (buildName, browserName, assets, failures) => {
   // SAUCE_JOB_NAME is only available for saucectl >= 0.16, hence the fallback
   let testName = process.env.SAUCE_JOB_NAME || `DevX Cypress Test Run - ${(new Date()).getTime()}`;
   let tags = process.env.SAUCE_TAGS;
@@ -123,13 +123,6 @@ SauceReporter.sauceReporter = async (buildName, browserName, testruns, failures)
   } catch (e) {
     console.warn('Failed to prepare test', e);
   }
-
-  const resultsFolder = 'cypress/results';
-  let specFiles = testruns.map((run) => run.spec.name);
-  let assets = await SauceReporter.prepareAssets(
-    specFiles,
-    process.env.SAUCE_REPORTS_DIR || resultsFolder,
-  );
 
   // upload assets
   await Promise.all([

--- a/tests/unit/src/cypress-runner.spec.js
+++ b/tests/unit/src/cypress-runner.spec.js
@@ -2,7 +2,7 @@ jest.mock('cypress');
 jest.mock('../../../src/sauce-reporter');
 
 const cypress = require('cypress');
-const { sauceReporter } = require('../../../src/sauce-reporter');
+const { sauceReporter, prepareAssets } = require('../../../src/sauce-reporter');
 const { cypressRunner } = require('../../../src/cypress-runner');
 
 describe('.cypressRunner', function () {
@@ -14,10 +14,11 @@ describe('.cypressRunner', function () {
     process.env = { ...oldEnv };
     cypressRunSpy.mockClear();
     const cypressRunResults = {
-      runs: ['spec-a', 'spec-b'],
+      runs: [{spec: {name: 'spec-a'}}, {spec: {name: 'spec-b'}}],
       failures: [],
     };
     cypress.run.mockImplementation(() => cypressRunResults);
+    prepareAssets.mockImplementation(() => (['spec-a', 'spec-b']));
   });
   it('can hardcode locations of reports, target and root', async function () {
     process.env.SAUCE_REPORTS_DIR = '/path/to/results';

--- a/tests/unit/src/cypress-runner.spec.js
+++ b/tests/unit/src/cypress-runner.spec.js
@@ -82,4 +82,18 @@ describe('.cypressRunner', function () {
       `Unsupported browser: 'lynx'. Sorry.`
     ));
   });
+  describe('from SAUCE VM', function () {
+    it('returns false if there are test failures', async function () {
+      process.env.SAUCE_VM = 'truthy';
+      cypressRunSpy.mockImplementation(() => ({failures: 100}));
+      const status = await cypressRunner();
+      expect(status).toEqual(false);
+    });
+    it('returns true if there are no test failures', async function () {
+      process.env.SAUCE_VM = 'truthy';
+      cypressRunSpy.mockImplementation(() => ({failures: 0}));
+      const status = await cypressRunner();
+      expect(status).toEqual(false);
+    });
+  });
 });

--- a/tests/unit/src/cypress-runner.spec.js
+++ b/tests/unit/src/cypress-runner.spec.js
@@ -18,6 +18,7 @@ describe('.cypressRunner', function () {
       failures: [],
     };
     cypress.run.mockImplementation(() => cypressRunResults);
+    prepareAssets.mockClear();
     prepareAssets.mockImplementation(() => (['spec-a', 'spec-b']));
   });
   it('can hardcode locations of reports, target and root', async function () {
@@ -51,6 +52,11 @@ describe('.cypressRunner', function () {
       }]
     ];
     expect(cypressRunSpy.mock.calls).toEqual(expectedCypressRun);
+    expect(prepareAssets.mock.calls).toEqual([
+      [
+        ['spec-a', 'spec-b'], '/path/to/results'
+      ]
+    ]);
   });
   it('can hardcode the browser path', async function () {
     process.env.BROWSER_NAME = 'chrome';

--- a/tests/unit/src/sauce-reporter.spec.js
+++ b/tests/unit/src/sauce-reporter.spec.js
@@ -65,30 +65,19 @@ describe('SauceReporter', function () {
     });
     it('should call uploadJobAssets on SauceLabs api', async function () {
       prepareAssetsSpy.mockReturnValue(['asset/one', 'asset/two']);
-      await SauceReporter.sauceReporter('build', 'browser', [{
-        spec: {name: 'MySpec'}, stats: {failures: 0}
-      }], 0);
+      await SauceReporter.sauceReporter('build', 'browser', ['asset/one', 'asset/two'], 0);
       expect(uploadJobAssetsSpy.mock.calls).toEqual([
         ['a', {'files': ['asset/one', 'asset/two']}]
       ]);
     });
     it('should output err when upload failed', async function () {
-      let originalConsole = console.error;
+      let consoleErrorSpy = jest.spyOn(global.console, 'error');
       prepareAssetsSpy.mockReturnValue(['asset/one', 'asset/two']);
-      await SauceReporter.sauceReporter('build', 'browser', [{
-        spec: {name: 'MySpec'}, stats: {failures: 0}
-      }]);
-
-      let consoleOutput = [];
-      const mockErr = output => consoleOutput.push(output);
-      console.error = mockErr;
-
+      await SauceReporter.sauceReporter('build', 'browser', ['asset/one', 'asset/two']);
       expect(uploadJobAssetsSpy.mock.calls).toEqual([
         ['a', {'files': ['asset/one', 'asset/two']}]
       ]);
-      expect(consoleOutput).calledOnce;
-
-      console.error = originalConsole;
+      expect(consoleErrorSpy.mock.calls).toEqual([['some fake error']]);
     });
   });
 });


### PR DESCRIPTION
* If a runner is running from inside of a Sauce VM, we don't need to create a job and upload the assets. This PR skips that step if it's a sauce VM
* Needed to do some refactoring though, because we still need the part of the recording code that prepares the assets