### PR TITLE
Integrate with global data store to create job

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8537,9 +8537,9 @@
       }
     },
     "saucelabs": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-4.5.1.tgz",
-      "integrity": "sha512-413cxGr0SlYi6jTvtHth8uTRFiPQ3F3dhr3Tjwh4OT1RVxLZ+QTZSyKDtAmMinXNJrGe2BULJjt+A5n1w10uUw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-4.6.0.tgz",
+      "integrity": "sha512-GAytkfq2QTVzwMS4/A99YQ79wqZvq29hO1r7+JYvfExRD9UipuvzvqhzsAfS8fKg+OuRIbIDTk0Rd7aWXa06zw==",
       "requires": {
         "bin-wrapper": "^4.1.0",
         "change-case": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "js-yaml": "3.14.0",
     "lodash": "4.17.20",
     "mocha-junit-reporter": "^2.0.0",
-    "saucelabs": "^4.5.0",
+    "saucelabs": "^4.6.0",
     "typescript": "^3.9.7",
     "webdriverio": "6.1.22",
     "yargs": "16.1.0"

--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -7,7 +7,7 @@ const cypress = require('cypress');
 const yargs = require('yargs/yargs');
 const _ = require('lodash');
 
-const report = async (results, browserName, runCfg, suiteName, startTime, endTime) => {
+const report = async (results, browserName, runCfg, suiteName) => {
   // Prepare the assets
   const runs = results.runs || [];
   let specFiles = runs.map((run) => run.spec.name);
@@ -26,7 +26,7 @@ const report = async (results, browserName, runCfg, suiteName, startTime, endTim
     return failures === 0;
   }
 
-  await sauceReporter(runCfg, suiteName, browserName, assets, failures, startTime, endTime);
+  await sauceReporter(runCfg, suiteName, browserName, assets, failures);
 
   return failures === 0;
 };
@@ -100,11 +100,9 @@ const cypressRunner = async function (runCfgPath, suiteName) {
 
   await installDependencies(runCfg);
   let cypressOpts = getCypressOpts(runCfg, suiteName);
-  let startTime = new Date().toISOString();
   const results = await cypress.run(cypressOpts);
-  let endTime = new Date().toISOString();
 
-  return await report(results, cypressOpts.browser, runCfg, suiteName, startTime, endTime);
+  return await report(results, cypressOpts.browser, runCfg, suiteName);
 };
 
 // For dev and test purposes, this allows us to run our Cypress Runner from command line

--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -7,7 +7,7 @@ const cypress = require('cypress');
 const yargs = require('yargs/yargs');
 const _ = require('lodash');
 
-const report = async (results, browserName, runCfg, suiteName) => {
+const report = async (results, browserName, runCfg, suiteName, startTime, endTime) => {
   // Prepare the assets
   const runs = results.runs || [];
   let specFiles = runs.map((run) => run.spec.name);
@@ -26,7 +26,7 @@ const report = async (results, browserName, runCfg, suiteName) => {
     return failures === 0;
   }
 
-  await sauceReporter(runCfg, suiteName, browserName, assets, failures);
+  await sauceReporter(runCfg, suiteName, browserName, assets, failures, startTime, endTime);
 
   return failures === 0;
 };
@@ -100,9 +100,11 @@ const cypressRunner = async function (runCfgPath, suiteName) {
 
   await installDependencies(runCfg);
   let cypressOpts = getCypressOpts(runCfg, suiteName);
+  let startTime = new Date().toISOString();
   const results = await cypress.run(cypressOpts);
+  let endTime = new Date().toISOString();
 
-  return await report(results, cypressOpts.browser, runCfg, suiteName);
+  return await report(results, cypressOpts.browser, runCfg, suiteName, startTime, endTime);
 };
 
 // For dev and test purposes, this allows us to run our Cypress Runner from command line

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -54,7 +54,7 @@ SauceReporter.prepareAssets = async (specFiles, resultsFolder) => {
   return assets;
 };
 
-SauceReporter.sauceReporter = async (runCfg, suiteName, browserName, assets, failures) => {
+SauceReporter.sauceReporter = async (runCfg, suiteName, browserName, assets, failures, startTime, endTime) => {
   const { sauce = {} } = runCfg;
   const { metadata = {} } = sauce;
   const baseTestName = metadata.name || `Test ${+new Date()}`;
@@ -78,8 +78,8 @@ SauceReporter.sauceReporter = async (runCfg, suiteName, browserName, assets, fai
           'value': process.env.SAUCE_USERNAME
         }
       ],
-      'start_time': '2020-11-20T17:18:11.168Z', // need collect
-      'end_time': '2020-11-20T17:18:11.168Z', // need collect
+      'start_time': startTime,
+      'end_time': endTime,
       'source': 'vdc', // will use devx
       'platform': 'webdriver', // will use cypress
       'status': 'complete',
@@ -88,17 +88,17 @@ SauceReporter.sauceReporter = async (runCfg, suiteName, browserName, assets, fai
       'attributes': {
         'container': false,
         'browser': browserName,
-        'commands_not_successful': 1, // need to be removed
+        'commands_not_successful': 1, // to be removed
         'devx': true,
         'os': 'test', // need collect
-        'performance_enabled': 'true', // need to be removed
+        'performance_enabled': 'true', // to be removed
         'public': 'team',
-        'record_logs': true, // need to bee removed
-        'record_mp4': 'true',
-        'record_screenshots': 'true',
-        'record_video': 'true',
-        'video_url': 'test', // will remove it
-        'log_url': 'test' // will remove it
+        'record_logs': true, // to be removed
+        'record_mp4': 'true', // to be removed
+        'record_screenshots': 'true', // to be removed
+        'record_video': 'true', // to be removed
+        'video_url': 'test', // remove
+        'log_url': 'test' // remove
       }
     };
 

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -172,13 +172,13 @@ SauceReporter.sauceReporter = async (runCfg, suiteName, browserName, assets, fai
     sessionId = await SauceReporter.createJobLegacy(api, region, browserName, testName, metadata);
   }
 
-  console.log('================')
-  console.log('================')
-  console.log('================')
-  console.log(sessionId)
-  console.log('================')
-  console.log('================')
-  console.log('================')
+  console.log('================');
+  console.log('================');
+  console.log('================');
+  console.log(sessionId);
+  console.log('================');
+  console.log('================');
+  console.log('================');
 
   if (!sessionId) {
     console.error('Unable to retrieve test entry. Assets won\'t be uploaded.');

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -10,6 +10,104 @@ const { remote } = require('webdriverio');
 
 const SauceReporter = {};
 
+// NOTE: this function is not available currently.
+// It will be ready once data store API actually works.
+// Keep these pieces of code for future integration.
+SauceReporter.createJobShell = async (api, testName, tags, browserName) => {
+  const body = {
+    'name': testName,
+    'acl': [
+      {
+        'type': 'username',
+        'value': process.env.SAUCE_USERNAME
+      }
+    ],
+    //'start_time': startTime,
+    //'end_time': endTime,
+    'source': 'vdc', // will use devx
+    'platform': 'webdriver', // will use cypress
+    'status': 'complete',
+    'live': false,
+    'metadata': {},
+    tags,
+    'attributes': {
+      'container': false,
+      'browser': browserName,
+      'browser_version': '*',
+      'commands_not_successful': 1, // to be removed
+      'devx': true,
+      'os': 'test', // need collect
+      'performance_enabled': 'true', // to be removed
+      'public': 'team',
+      'record_logs': true, // to be removed
+      'record_mp4': 'true', // to be removed
+      'record_screenshots': 'true', // to be removed
+      'record_video': 'true', // to be removed
+      'video_url': 'test', // remove
+      'log_url': 'test' // remove
+    }
+  };
+
+  let sessionId;
+  await api.createResultJob(
+    body
+  ).then(
+    (resp) => {
+      sessionId = resp.id;
+    },
+    (e) => console.error('Create job failed: ', e.stack)
+  );
+
+  if (!sessionId) {
+    return 0;
+  }
+
+  return sessionId;
+};
+
+SauceReporter.createJobLegacy = async (api, region, browserName, testName, metadata) => {
+  try {
+    await remote({
+      user: process.env.SAUCE_USERNAME,
+      key: process.env.SAUCE_ACCESS_KEY,
+      region,
+      connectionRetryCount: 0,
+      logLevel: 'silent',
+      capabilities: {
+        browserName,
+        platformName: '*',
+        browserVersion: '*',
+        'sauce:options': {
+          devX: true,
+          name: testName,
+          framework: 'cypress',
+          build: metadata.build,
+          tags: metadata.tags,
+        }
+      }
+    }).catch((err) => err);
+  } catch (e) {
+    console.error(e);
+  }
+
+  let sessionId;
+  try {
+    const { jobs } = await api.listJobs(
+      process.env.SAUCE_USERNAME,
+      { limit: 1, full: true, name: testName }
+    );
+    sessionId = jobs && jobs.length && jobs[0].id;
+  } catch (e) {
+    console.warn('Failed to prepare test', e);
+  }
+
+  if (!sessionId) {
+    return 0;
+  }
+
+  return sessionId;
+};
+
 SauceReporter.prepareAssets = async (specFiles, resultsFolder) => {
   const assets = [];
   const videos = [];
@@ -54,7 +152,7 @@ SauceReporter.prepareAssets = async (specFiles, resultsFolder) => {
   return assets;
 };
 
-SauceReporter.sauceReporter = async (runCfg, suiteName, browserName, assets, failures, startTime, endTime) => {
+SauceReporter.sauceReporter = async (runCfg, suiteName, browserName, assets, failures) => {
   const { sauce = {} } = runCfg;
   const { metadata = {} } = sauce;
   const baseTestName = metadata.name || `Test ${+new Date()}`;
@@ -64,95 +162,20 @@ SauceReporter.sauceReporter = async (runCfg, suiteName, browserName, assets, fai
   const api = new SauceLabs({
     user: process.env.SAUCE_USERNAME,
     key: process.env.SAUCE_ACCESS_KEY,
-    region
+    region: 'staging',
+    tld: 'net'
   });
 
   let sessionId;
-
-  if (process.env.ENABLE_PLATFORM === true) {
-    const body = {
-      'name': testName,
-      'acl': [
-        {
-          'type': 'username',
-          'value': process.env.SAUCE_USERNAME
-        }
-      ],
-      'start_time': startTime,
-      'end_time': endTime,
-      'source': 'vdc', // will use devx
-      'platform': 'webdriver', // will use cypress
-      'status': 'complete',
-      'live': false,
-      'metadata': {},
-      'tags': metadata.tags,
-      'attributes': {
-        'container': false,
-        'browser': browserName,
-        'browser_version': '*',
-        'commands_not_successful': 1, // to be removed
-        'devx': true,
-        'os': 'test', // need collect
-        'performance_enabled': 'true', // to be removed
-        'public': 'team',
-        'record_logs': true, // to be removed
-        'record_mp4': 'true', // to be removed
-        'record_screenshots': 'true', // to be removed
-        'record_video': 'true', // to be removed
-        'video_url': 'test', // remove
-        'log_url': 'test' // remove
-      }
-    };
-
-    await Promise.all([
-      api.createResultJob(
-        body
-      ).then(
-        (resp) => {
-          sessionId = resp.id;
-        },
-        (e) => console.error('Create job failed: ', e.stack)
-      )
-    ]);
+  if (process.env.ENABLE_DATA_STORE) {
+    sessionId = await SauceReporter.createJobShell(api, testName, metadata.tags, browserName);
   } else {
-    try {
-      await remote({
-        user: process.env.SAUCE_USERNAME,
-        key: process.env.SAUCE_ACCESS_KEY,
-        region,
-        connectionRetryCount: 0,
-        logLevel: 'silent',
-        capabilities: {
-          browserName,
-          platformName: '*',
-          browserVersion: '*',
-          'sauce:options': {
-            devX: true,
-            name: testName,
-            framework: 'cypress',
-            build: metadata.build,
-            tags: metadata.tags,
-          }
-        }
-      }).catch((err) => err);
-    } catch (e) {
-      console.log(e);
-    }
+    sessionId = await SauceReporter.createJobLegacy(api, region, browserName, testName, metadata);
+  }
 
-    try {
-      const { jobs } = await api.listJobs(
-        process.env.SAUCE_USERNAME,
-        { limit: 1, full: true, name: testName }
-      );
-      sessionId = jobs && jobs.length && jobs[0].id;
-    } catch (e) {
-      console.warn('Failed to prepare test', e);
-    }
-
-    if (undefined === sessionId || 0 === sessionId) {
-      console.error('Unable to retrieve test entry. Assets won\'t be uploaded.');
-      return 'unable to retrieve test';
-    }
+  if (!sessionId) {
+    console.error('Unable to retrieve test entry. Assets won\'t be uploaded.');
+    return 'unable to retrieve test';
   }
 
   // upload assets

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -15,36 +15,36 @@ const SauceReporter = {};
 // Keep these pieces of code for future integration.
 SauceReporter.createJobShell = async (api, testName, tags, browserName) => {
   const body = {
-    'name': testName,
-    'acl': [
+    name: testName,
+    acl: [
       {
-        'type': 'username',
-        'value': process.env.SAUCE_USERNAME
+        type: 'username',
+        value: process.env.SAUCE_USERNAME
       }
     ],
-    //'start_time': startTime,
-    //'end_time': endTime,
-    'source': 'vdc', // will use devx
-    'platform': 'webdriver', // will use cypress
-    'status': 'complete',
-    'live': false,
-    'metadata': {},
+    //'start_time: startTime,
+    //'end_time: endTime,
+    source: 'vdc', // will use devx
+    platform: 'webdriver', // will use cypress
+    status: 'complete',
+    live: false,
+    metadata: {},
     tags,
-    'attributes': {
-      'container': false,
-      'browser': browserName,
-      'browser_version': '*',
-      'commands_not_successful': 1, // to be removed
-      'devx': true,
-      'os': 'test', // need collect
-      'performance_enabled': 'true', // to be removed
-      'public': 'team',
-      'record_logs': true, // to be removed
-      'record_mp4': 'true', // to be removed
-      'record_screenshots': 'true', // to be removed
-      'record_video': 'true', // to be removed
-      'video_url': 'test', // remove
-      'log_url': 'test' // remove
+    attributes: {
+      container: false,
+      browser: browserName,
+      browser_version: '*',
+      commands_not_successful: 1, // to be removed
+      devx: true,
+      os: 'test', // need collect
+      performance_enabled: 'true', // to be removed
+      public: 'team',
+      record_logs: true, // to be removed
+      record_mp4: 'true', // to be removed
+      record_screenshots: 'true', // to be removed
+      record_video: 'true', // to be removed
+      video_url: 'test', // remove
+      log_url: 'test' // remove
     }
   };
 
@@ -58,11 +58,7 @@ SauceReporter.createJobShell = async (api, testName, tags, browserName) => {
     (e) => console.error('Create job failed: ', e.stack)
   );
 
-  if (!sessionId) {
-    return 0;
-  }
-
-  return sessionId;
+  return sessionId || 0;
 };
 
 SauceReporter.createJobLegacy = async (api, region, browserName, testName, metadata) => {
@@ -101,11 +97,7 @@ SauceReporter.createJobLegacy = async (api, region, browserName, testName, metad
     console.warn('Failed to prepare test', e);
   }
 
-  if (!sessionId) {
-    return 0;
-  }
-
-  return sessionId;
+  return sessionId || 0;
 };
 
 SauceReporter.prepareAssets = async (specFiles, resultsFolder) => {

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -69,7 +69,7 @@ SauceReporter.sauceReporter = async (runCfg, suiteName, browserName, assets, fai
 
   let sessionId;
 
-  if (process.env.ENABLE_PLATFORM) {
+  if (process.env.ENABLE_PLATFORM === true) {
     const body = {
       'name': testName,
       'acl': [

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -172,14 +172,6 @@ SauceReporter.sauceReporter = async (runCfg, suiteName, browserName, assets, fai
     sessionId = await SauceReporter.createJobLegacy(api, region, browserName, testName, metadata);
   }
 
-  console.log('================');
-  console.log('================');
-  console.log('================');
-  console.log(sessionId);
-  console.log('================');
-  console.log('================');
-  console.log('================');
-
   if (!sessionId) {
     console.error('Unable to retrieve test entry. Assets won\'t be uploaded.');
     return 'unable to retrieve test';

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -162,8 +162,7 @@ SauceReporter.sauceReporter = async (runCfg, suiteName, browserName, assets, fai
   const api = new SauceLabs({
     user: process.env.SAUCE_USERNAME,
     key: process.env.SAUCE_ACCESS_KEY,
-    region: 'staging',
-    tld: 'net'
+    region
   });
 
   let sessionId;

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -85,9 +85,11 @@ SauceReporter.sauceReporter = async (runCfg, suiteName, browserName, assets, fai
       'status': 'complete',
       'live': false,
       'metadata': {},
+      'tags': metadata.tags,
       'attributes': {
         'container': false,
         'browser': browserName,
+        'browser_version': '*',
         'commands_not_successful': 1, // to be removed
         'devx': true,
         'os': 'test', // need collect

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -172,6 +172,14 @@ SauceReporter.sauceReporter = async (runCfg, suiteName, browserName, assets, fai
     sessionId = await SauceReporter.createJobLegacy(api, region, browserName, testName, metadata);
   }
 
+  console.log('================')
+  console.log('================')
+  console.log('================')
+  console.log(sessionId)
+  console.log('================')
+  console.log('================')
+  console.log('================')
+
   if (!sessionId) {
     console.error('Unable to retrieve test entry. Assets won\'t be uploaded.');
     return 'unable to retrieve test';

--- a/tests/unit/src/__snapshots__/sauce-reporter.spec.js.snap
+++ b/tests/unit/src/__snapshots__/sauce-reporter.spec.js.snap
@@ -9,3 +9,52 @@ Array [
   "results/video.mp4",
 ]
 `;
+
+exports[`SauceReporter .sauceReporter should create job via global data store 1`] = `
+Array [
+  Array [
+    Object {
+      "acl": Array [
+        Object {
+          "type": "username",
+          "value": "fake-user",
+        },
+      ],
+      "attributes": Object {
+        "browser": "browser",
+        "browser_version": "*",
+        "commands_not_successful": 1,
+        "container": false,
+        "devx": true,
+        "log_url": "test",
+        "os": "test",
+        "performance_enabled": "true",
+        "public": "team",
+        "record_logs": true,
+        "record_mp4": "true",
+        "record_screenshots": "true",
+        "record_video": "true",
+        "video_url": "test",
+      },
+      "live": false,
+      "metadata": Object {},
+      "name": "Fake Name - build",
+      "platform": "webdriver",
+      "source": "vdc",
+      "status": "complete",
+      "tags": undefined,
+    },
+  ],
+]
+`;
+
+exports[`SauceReporter .sauceReporter should output err when upload failed 1`] = `
+Array [
+  Array [
+    [TypeError: Cannot read property 'catch' of undefined],
+  ],
+  Array [
+    "some fake error",
+  ],
+]
+`;

--- a/tests/unit/src/sauce-reporter.spec.js
+++ b/tests/unit/src/sauce-reporter.spec.js
@@ -89,7 +89,6 @@ describe('SauceReporter', function () {
       prepareAssetsSpy.mockReturnValue(['asset/one', 'asset/two']);
       await SauceReporter.sauceReporter(fakeRunConfig, 'build', 'browser', ['asset/one', 'asset/two'], 0);
       expect(createJobSpy).toBeCalled();
-      createJobSpy.mockReturnValue({ error: ['fake error'] });
     });
   });
 });

--- a/tests/unit/src/sauce-reporter.spec.js
+++ b/tests/unit/src/sauce-reporter.spec.js
@@ -89,7 +89,6 @@ describe('SauceReporter', function () {
       process.env.ENABLE_DATA_STORE = 'true';
       prepareAssetsSpy.mockReturnValue(['asset/one', 'asset/two']);
       await SauceReporter.sauceReporter(fakeRunConfig, 'build', 'browser', ['asset/one', 'asset/two'], 0);
-      expect(createJobSpy).toBeCalled();
       expect(createJobSpy.mock.calls).toMatchSnapshot();
     });
     it ('should fail when global data store throws error', async function () {

--- a/tests/unit/src/sauce-reporter.spec.js
+++ b/tests/unit/src/sauce-reporter.spec.js
@@ -62,7 +62,7 @@ describe('SauceReporter', function () {
       expect(uploadJobAssetsSpy.mock.calls).toEqual([
         ['a', {'files': ['asset/one', 'asset/two']}]
       ]);
-      expect(consoleErrorSpy.mock.calls).not.empty;
+      expect(consoleErrorSpy.mock.calls).toMatchSnapshot();
     });
     it('should not push assets when no sessionId from SauceLabs API', async function () {
       SauceLabs.default.mockImplementation(function () {

--- a/tests/unit/src/sauce-reporter.spec.js
+++ b/tests/unit/src/sauce-reporter.spec.js
@@ -41,7 +41,7 @@ describe('SauceReporter', function () {
       prepareAssetsSpy = jest.spyOn(SauceReporter, 'prepareAssets');
       // eslint-disable-next-line require-await
       uploadJobAssetsSpy = jest.fn().mockImplementation(async () => ({errors: ['some fake error']}));
-      createJobSpy = jest.fn().mockImplementation(() => ({sessionId: '123'}));
+      createJobSpy = jest.fn().mockImplementation(async () => (await {sessionId: '123'}));
       SauceLabs.default.mockImplementation(function () {
         // eslint-disable-next-line require-await
         this.listJobs = async () => ({

--- a/tests/unit/src/sauce-reporter.spec.js
+++ b/tests/unit/src/sauce-reporter.spec.js
@@ -90,8 +90,6 @@ describe('SauceReporter', function () {
       await SauceReporter.sauceReporter(fakeRunConfig, 'build', 'browser', ['asset/one', 'asset/two'], 0);
       expect(createJobSpy).toBeCalled();
       createJobSpy.mockReturnValue({ error: ['fake error'] });
-      expect(createJobSpy).not.toBeCalled();
-      expect(createJobSpy.mock.calls).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
Create test result job via global data store. Currently the new approach is existed along with the previous one and will be enabled by env var `ENABLE_DATA_STORE`.
Currently even with workable creating job part, the legacy uploading part cannot co-operate with it.