### PR TITLE
KitchenSink - Avoid ambigous execution in case of build failure

### DIFF
--- a/.github/workflows/kitchen-sink.yml
+++ b/.github/workflows/kitchen-sink.yml
@@ -25,7 +25,7 @@ jobs:
           context: .
           file: ./Dockerfile
           tags: |
-            saucelabs/stt-cypress-mocha-node:latest
+            saucelabs/stt-cypress-mocha-node:local
 
       - name: Install saucectl
         run: |

--- a/tests/kitchen-sink-tests/.sauce/config.yml
+++ b/tests/kitchen-sink-tests/.sauce/config.yml
@@ -21,7 +21,7 @@ suites:
 docker:
   image:
     name: saucelabs/stt-cypress-mocha-node
-    tag: latest
+    tag: local
 
 sauce:
   region: us-west-1


### PR DESCRIPTION
Related: https://github.com/saucelabs/sauce-cypress-runner/pull/65#discussion_r534333004
