### PR TITLE
fix: re-arrange logging ot be more clear

### DIFF
--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -8,6 +8,11 @@ const yargs = require('yargs/yargs');
 const _ = require('lodash');
 
 const report = async (results, browserName, runCfg, suiteName) => {
+  if (process.env.SAUCE_VM) {
+    // Don't do any reporting from within a Sauce VM.
+    // Sauce VM's handle reporting externally
+    return;
+  }
   // Prepare the assets
   const runs = results.runs || [];
   let specFiles = runs.map((run) => run.spec.name);

--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -8,28 +8,23 @@ const yargs = require('yargs/yargs');
 const _ = require('lodash');
 
 const report = async (results, browserName, runCfg, suiteName) => {
-  if (process.env.SAUCE_VM) {
-    // Don't do any reporting from within a Sauce VM.
-    // Sauce VM's handle reporting externally
-    return;
-  }
   // Prepare the assets
   const runs = results.runs || [];
   let specFiles = runs.map((run) => run.spec.name);
-  let assets = await prepareAssets(
-      specFiles,
-      runCfg.resultsDir,
-  );
 
   let failures = results.failures || results.totalFailed;
+  if (process.env.SAUCE_VM) {
+    return failures === 0;
+  }
   if (!(process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY)) {
     console.log('Skipping asset uploads! Remember to setup your SAUCE_USERNAME/SAUCE_ACCESS_KEY');
     return failures === 0;
   }
-  if (process.env.SAUCE_VM) {
-    console.log('Skipping asset upload inside of sauce vm. Asset uploads will take place in post process batch job');
-    return failures === 0;
-  }
+
+  let assets = await prepareAssets(
+      specFiles,
+      runCfg.resultsDir,
+  );
 
   await sauceReporter(runCfg, suiteName, browserName, assets, failures);
 

--- a/tests/unit/src/cypress-runner.spec.js
+++ b/tests/unit/src/cypress-runner.spec.js
@@ -39,8 +39,8 @@ describe('.cypressRunner', function () {
     fs.readFileSync.mockImplementation(() => JSON.stringify(fakeRunnerJson));
   });
   it('can call Cypress.run with basic args', async function () {
-    process.env.SAUCE_USERNAME = null;
-    process.env.SAUCE_ACCESS_KEY = null;
+    process.env.SAUCE_USERNAME = 'fake-sauce-username';
+    process.env.SAUCE_ACCESS_KEY = 'fake-sauce-accesskey';
     await cypressRunner('/fake/runner/path', 'fake-suite');
     // Change reporter to not be fully-qualified path
     const {reporter} = cypressRunSpy.mock.calls[0][0].config;


### PR DESCRIPTION
* Moved `prepareAssets` to after the point where we check for SAUCE_VM or sauce credentials (SAUCE_USERNAME/SAUCE_ACCESS_KEY)
* Removed the message `Skipping asset upload inside of sauce vm. Asset uploads will take place in post process batch job` because that's confusing to users who are viewing their jobs from inside a VM. Users don't have a concept of "post process batch job" and the message "Skipping asset upload" implies that something went wrong
* Moved the check for SAUCE_VM early in the method so that these logs don't show up in our VM's

```
Failed to prepare asset. Could not find: 'c:\chef\code\__project__\cypress-basic-test\__assets__\example.test.js.mp4'
Skipping asset uploads! Remember to setup your
```
