### PR TITLE
Remove CI support due to newly native config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,4 @@ ENV CYPRESS_CACHE_FOLDER=/home/seluser/.cache/Cypress
 # Let saucectl know where to mount files
 LABEL com.saucelabs.project-dir=/home/seluser/
 
-# Workaround for permissions in CI if run with a different user
-RUN chmod 777 -R /home/seluser/
-
 CMD ["./entry.sh"]


### PR DESCRIPTION
As we have moved to native configuration for Cypress, CI mode is no more required.

Removing support of CI mode will remove on layer that copies all the files in home and have a huge impact on image size (-29%).

```
REPOSITORY                                               TAG                IMAGE ID       CREATED           SIZE
saucelabs/stt-cypress-mocha-node                         latest             b60778989071   18 minutes ago    2.15GB
saucelabs/stt-cypress-mocha-node                         old-latest         9a815b9a989b   19 minutes ago    3.01GB
```