### PR TITLE
Do not create job when there is no credentials

### DIFF
--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -24,7 +24,9 @@ const report = async (results, browserName, runCfg, suiteName, startTime, endTim
     runCfg.resultsDir,
   );
 
-  await sauceReporter(runCfg, suiteName, browserName, assets, failures, startTime, endTime);
+  if (process.env.SAUCE_USERNAME !== '' && process.env.SAUCE_ACCESS_KEY !== '') {
+    await sauceReporter(runCfg, suiteName, browserName, assets, failures, startTime, endTime);
+  }
 
   return failures === 0;
 };


### PR DESCRIPTION
It should display following instead of trying to create job when no credentials set
```
Skipping asset uploads! Remember to setup your SAUCE_USERNAME/SAUCE_ACCESS_KEY
```