### PR TITLE
Implement cypress-sync'd version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Prepare
-        id: prep
+      - name: Check that cypress version is synced
+        shell: bash -x
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
-          echo ::set-output name=version::${VERSION}
-      - name: Check that cypress version is sync'd
-        run: |
-          < package.json  jq -r '.dependencies["cypress"]'
           CYPRESS_VERSION=`< package.json  jq -r '.dependencies["cypress"]'`
-          echo test "${CYPRESS_VERSION}" = "${VERSION}"
           test "${CYPRESS_VERSION}" = "${VERSION}"
   release-github:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,22 @@ on:
   push:
     tags:
       - '*.*.*'
-jobs:  
+jobs:
+  version-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare
+        id: prep
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          echo ::set-output name=version::${VERSION}
+      - name: Check that cypress version is sync'd
+        run: |
+          CYPRESS_VERSION=`< package.json  jq -r '.dependencies["cypress"]'`
+          test "${CYPRESS_VERSION}" = "${VERSION}"
   release-github:
     runs-on: ubuntu-latest
+    needs: version-consistency
     steps:
       - name: Prepare
         id: prep
@@ -31,6 +44,7 @@ jobs:
           draft: false
   release-docker:
     runs-on: ubuntu-latest
+    needs: version-consistency
     steps:
       -
         name: Checkout
@@ -65,7 +79,7 @@ jobs:
             BUILD_TAG=${{ steps.prep.outputs.version }}
   release-windows-bundle:
     runs-on: windows-latest
-    needs: release-github
+    needs: [release-github, version-consistency]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
           release_name: Release ${{ steps.prep.outputs.version }}
           body: Release ${{ steps.prep.outputs.version }}
           draft: false
+          prerelease: false
   release-docker:
     runs-on: ubuntu-latest
     needs: version-consistency

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,18 +59,17 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/}
           echo ::set-output name=version::${VERSION}
           npm version --no-git-tag-version ${VERSION}
-      # -
-      #   name: Login to DockerHub
-      #   uses: docker/login-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKER_USERNAME }}
-      #     password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
-          # push: true
-          push: false
+          push: true
           context: .
           file: ./Dockerfile
           tags: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   version-consistency:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Prepare
         id: prep
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${{ steps.get_release_id.outputs.release_id }}/assets?name=saucetpl.tar.gz
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.get_release_id.outputs.release_id }}/assets?name=saucetpl.tar.gz
           asset_path: ./saucetpl.tar.gz
           asset_name: saucetpl.tar.gz
           asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,9 @@ jobs:
           echo ::set-output name=version::${VERSION}
       - name: Check that cypress version is sync'd
         run: |
+          < package.json  jq -r '.dependencies["cypress"]'
           CYPRESS_VERSION=`< package.json  jq -r '.dependencies["cypress"]'`
+          echo test "${CYPRESS_VERSION}" = "${VERSION}"
           test "${CYPRESS_VERSION}" = "${VERSION}"
   release-github:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Docker Release
 on:
   push:
     tags:
-      - '*.*.*'
+      - 'v*.*.*'
 jobs:
   version-consistency:
     runs-on: ubuntu-latest
@@ -16,8 +16,8 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
           CYPRESS_VERSION=`< package.json  jq -r '.dependencies["cypress"]'`
-          echo Comparing "${CYPRESS_VERSION}" with "${VERSION}"
-          test "${CYPRESS_VERSION}" = "${VERSION}"
+          echo Comparing "v${CYPRESS_VERSION}" with "${VERSION}"
+          test "v${CYPRESS_VERSION}" = "${VERSION}"
   release-github:
     runs-on: ubuntu-latest
     needs: version-consistency

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Docker Release
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - '*.*.*'
 jobs:  
   release-github:
     runs-on: ubuntu-latest
@@ -17,7 +17,7 @@ jobs:
           echo ::set-output name=version::${VERSION}
       - name: Check if release exists
         id: check_release
-        run: echo ::set-output name=success::$(curl -s -o /dev/null -w "%{http_code}" https://api.github.com/repos/saucelabs/sauce-cypress-runner/releases/tags/${{ steps.prep.outputs.version }})
+        run: echo ::set-output name=success::$(curl -s -o /dev/null -w "%{http_code}" https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${{ steps.prep.outputs.version }})
       - name: Create Release
         if: steps.check_release.outputs.success != '200'
         id: create_release
@@ -55,7 +55,7 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v2
         with:
-          push: true
+          push: false
           context: .
           file: ./Dockerfile
           tags: |
@@ -106,7 +106,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: https://uploads.github.com/repos/saucelabs/sauce-cypress-runner/releases/${{ steps.get_release_id.outputs.release_id }}/assets?name=sauce-cypress-runner.zip
+          upload_url: https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${{ steps.get_release_id.outputs.release_id }}/assets?name=sauce-cypress-runner.zip
           asset_path: ./sauce-cypress-win.zip
           asset_name: sauce-cypress-win.zip
           asset_content_type: application/zip
@@ -144,7 +144,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: https://uploads.github.com/repos/saucelabs/sauce-cypress-runner/releases/${{ steps.get_release_id.outputs.release_id }}/assets?name=saucetpl.tar.gz
+          upload_url: https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${{ steps.get_release_id.outputs.release_id }}/assets?name=saucetpl.tar.gz
           asset_path: ./saucetpl.tar.gz
           asset_name: saucetpl.tar.gz
           asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,9 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
           CYPRESS_VERSION=`< package.json  jq -r '.dependencies["cypress"]'`
-          echo Comparing "v${CYPRESS_VERSION}" with "${VERSION}"
-          test "v${CYPRESS_VERSION}" = "${VERSION}"
+          CYPRESS_VERSION_LOCKED=`jq < package-lock.json -r '.dependencies["cypress"].version'`
+          echo Comparing "${VERSION}" with "v${CYPRESS_VERSION}"  and "v${CYPRESS_VERSION_LOCKED}"
+          test "v${CYPRESS_VERSION}" = "${VERSION}" && test "v${CYPRESS_VERSION_LOCKED}" = "${VERSION}"
   release-github:
     runs-on: ubuntu-latest
     needs: version-consistency

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           echo ::set-output name=version::${VERSION}
       - name: Check if release exists
         id: check_release
-        run: echo ::set-output name=success::$(curl -s -o /dev/null -w "%{http_code}" https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${{ steps.prep.outputs.version }})
+        run: echo ::set-output name=success::$(curl -s -o /dev/null -w "%{http_code}" https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ steps.prep.outputs.version }})
       - name: Create Release
         if: steps.check_release.outputs.success != '200'
         id: create_release
@@ -120,7 +120,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${{ steps.get_release_id.outputs.release_id }}/assets?name=sauce-cypress-runner.zip
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.get_release_id.outputs.release_id }}/assets?name=sauce-cypress-runner.zip
           asset_path: ./sauce-cypress-win.zip
           asset_name: sauce-cypress-win.zip
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Check that cypress version is synced
-        shell: bash -x
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
           CYPRESS_VERSION=`< package.json  jq -r '.dependencies["cypress"]'`
+          echo Comparing "${CYPRESS_VERSION}" with "${VERSION}"
           test "${CYPRESS_VERSION}" = "${VERSION}"
   release-github:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,16 +58,17 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/}
           echo ::set-output name=version::${VERSION}
           npm version --no-git-tag-version ${VERSION}
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+      # -
+      #   name: Login to DockerHub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_PASSWORD }}
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
+          # push: true
           push: false
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
As we are moving forward, we would to align cypress runner version with cypress version.

This PR slightly modify the pipeline to ensure we are creating a release matching the defined version of Cypress.

Successful pipeline: https://github.com/FriggaHel/sauce-cypress-runner/actions/runs/499145675
Failing pipeline: https://github.com/FriggaHel/sauce-cypress-runner/runs/1736707125?check_suite_focus=true