### PR TITLE
Support framework version as substring inside tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Check that cypress version is synced
+      - name: Check that cypress version is part of the tag
         run: |
-          VERSION=${GITHUB_REF#refs/tags/}
-          CYPRESS_VERSION=`< package.json  jq -r '.dependencies["cypress"]'`
-          CYPRESS_VERSION_LOCKED=`jq < package-lock.json -r '.dependencies["cypress"].version'`
-          echo Comparing "${VERSION}" with "v${CYPRESS_VERSION}"  and "v${CYPRESS_VERSION_LOCKED}"
-          test "v${CYPRESS_VERSION}" = "${VERSION}" && test "v${CYPRESS_VERSION_LOCKED}" = "${VERSION}"
+          ./verify_tag.sh
   release-github:
     runs-on: ubuntu-latest
     needs: version-consistency

--- a/verify_tag.sh
+++ b/verify_tag.sh
@@ -1,0 +1,9 @@
+VERSION=${GITHUB_REF#refs/tags/}
+CYPRESS_VERSION=`< package.json  jq -r '.dependencies["cypress"]'`
+CYPRESS_VERSION_LOCKED=`jq < package-lock.json -r '.dependencies["cypress"].version'`
+echo Comparing "${VERSION}" with "v${CYPRESS_VERSION}" and "v${CYPRESS_VERSION_LOCKED}"
+if [[ "${VERSION}" != "v${CYPRESS_VERSION}"* ]] || [[ "${VERSION}" != "v${CYPRESS_VERSION_LOCKED}"* ]]; then
+  echo "Release tag does not include the actual cypress version!"
+  exit 1
+fi
+echo All clear!


### PR DESCRIPTION
Support framework version as substring inside tags.

Thus a tag like `v5.6.0+v0.1.0` ought to be possible now.