### PR TITLE
Removing the version enforcement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,6 @@ on:
     tags:
       - 'v*.*.*'
 jobs:
-  version-consistency:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Check that cypress version is part of the tag
-        run: |
-          ./verify_tag.sh
   release-github:
     runs-on: ubuntu-latest
     needs: version-consistency


### PR DESCRIPTION
Removing the version enforcement, since we aren't going to include the framework version as part of the release tags anymore.