### PR TITLE
Docker: Store job details url in file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV CYPRESS_CACHE_FOLDER=/home/seluser/.cache/Cypress
 
 # Let saucectl know where to mount files
 LABEL com.saucelabs.project-dir=/home/seluser/
-LABEL com.saucelabs.job-details-url=/tmp/output-job-details-url
+LABEL com.saucelabs.job-info=/tmp/output.json
 
 # Workaround for permissions in CI if run with a different user
 RUN chmod 777 -R /home/seluser/

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ ENV CYPRESS_CACHE_FOLDER=/home/seluser/.cache/Cypress
 
 # Let saucectl know where to mount files
 LABEL com.saucelabs.project-dir=/home/seluser/
+LABEL com.saucelabs.job-details-url=/tmp/output-job-details-url
 
 # Workaround for permissions in CI if run with a different user
 RUN chmod 777 -R /home/seluser/

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -278,8 +278,10 @@ SauceReporter.sauceReporter = async (runCfg, suiteName, browserName, assets, fai
   console.log(`\nOpen job details page: ${jobDetailsUrl}\n`);
 
   // Store file containing job-details url.
-  // Path is similar to com.saucelabs.job-details-url LABEL in Dockerfile.
-  fs.writeFileSync('/tmp/output-job-details-url', jobDetailsUrl);
+  // Path is similar to com.saucelabs.job-info LABEL in Dockerfile.
+  fs.writeFileSync('/tmp/output.json', JSON.stringify({
+    jobDetailsUrl,
+  }));
 };
 
 SauceReporter.mergeVideos = async (videos, target) => {

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -274,7 +274,12 @@ SauceReporter.sauceReporter = async (runCfg, suiteName, browserName, assets, fai
       break;
   }
 
-  console.log(`\nOpen job details page: https://app.${domain}/tests/${sessionId}\n`);
+  const jobDetailsUrl = `https://app.${domain}/tests/${sessionId}`;
+  console.log(`\nOpen job details page: ${jobDetailsUrl}\n`);
+
+  // Store file containing job-details url.
+  // Path is similar to com.saucelabs.job-details-url LABEL in Dockerfile.
+  fs.writeFileSync('/tmp/output-job-details-url', jobDetailsUrl);
 };
 
 SauceReporter.mergeVideos = async (videos, target) => {


### PR DESCRIPTION
In docker mode, store job detail URL in a file to allow saucectl to retrieve it.