### PR TITLE
Don't filter by draft releases for post-release tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,5 +265,5 @@ jobs:
         run: |
           VERSION=$(curl -s -H "Authorization: token ${{ github.token }}" \
                       https://api.github.com/repos/${{ github.repository }}/releases | \
-                      jq -r "[.[] | select(.draft == true) | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .tag_name")
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .tag_name")
           npx saucectl run --test-env sauce --ccy 5 --region us-west-1 --runner-version "github-release: ${VERSION}"

--- a/tests/kitchen-sink-tests/.sauce/config.yml
+++ b/tests/kitchen-sink-tests/.sauce/config.yml
@@ -25,4 +25,4 @@ suites:
       testFiles: [ "examples/*.*" ]
 
 docker:
-  image: saucelabs/stt-cypress-mocha-node:latest
+  image: saucelabs/stt-cypress-mocha-node:local


### PR DESCRIPTION
post-release-windows-tests job runs after publish-release so when it looks for the release tag_name, don't filter by drafts.