### PR TITLE
Use action to run tests

### DIFF
--- a/.github/workflows/kitchen-sink.yml
+++ b/.github/workflows/kitchen-sink.yml
@@ -31,18 +31,13 @@ jobs:
           tags: |
             saucelabs/stt-cypress-mocha-node:local
 
-      - name: Install saucectl
-        run: |
-          LATEST_TAG=`curl -s https://api.github.com/repos/saucelabs/saucectl/releases/latest | jq -r '.name'`
-          LATEST_VERSION=`echo ${LATEST_TAG} | sed s/v//`
-          curl -s -L https://github.com/saucelabs/saucectl/releases/download/${LATEST_TAG}/saucectl_${LATEST_VERSION}_linux_64-bit.tar.gz | sudo tar -xvz -C /usr/bin/
-
-      - name: Run kitchen sink test
-        working-directory: ./tests/kitchen-sink-tests
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+      - name: Change user for cypress files
         run: |
           sudo chown -R 1000:1000 ./cypress
-          saucectl run
 
+      - name: Run kitchen sink test
+        use: saucelabs/saucectl-run-action@v1
+        with:
+          working-directory: ./tests/kitchen-sink-tests
+          sauce-username: ${{ secrets.SAUCE_USERNAME }}
+          sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/.github/workflows/kitchen-sink.yml
+++ b/.github/workflows/kitchen-sink.yml
@@ -36,7 +36,7 @@ jobs:
           sudo chown -R 1000:1000 ./tests/kitchen-sink-tests/cypress
 
       - name: Run kitchen sink test
-        uses: saucelabs/saucectl-run-action@check-execution
+        uses: saucelabs/saucectl-run-action@v1
         with:
           working-directory: ./tests/kitchen-sink-tests
           sauce-username: ${{ secrets.SAUCE_USERNAME }}

--- a/.github/workflows/kitchen-sink.yml
+++ b/.github/workflows/kitchen-sink.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Change user for cypress files
         run: |
-          sudo chown -R 1000:1000 ./cypress
+          sudo chown -R 1000:1000 ./tests/kitchen-sink-tests/cypress
 
       - name: Run kitchen sink test
         uses: saucelabs/saucectl-run-action@v1

--- a/.github/workflows/kitchen-sink.yml
+++ b/.github/workflows/kitchen-sink.yml
@@ -36,7 +36,7 @@ jobs:
           sudo chown -R 1000:1000 ./tests/kitchen-sink-tests/cypress
 
       - name: Run kitchen sink test
-        uses: saucelabs/saucectl-run-action@v1
+        uses: saucelabs/saucectl-run-action@check-execution
         with:
           working-directory: ./tests/kitchen-sink-tests
           sauce-username: ${{ secrets.SAUCE_USERNAME }}

--- a/.github/workflows/kitchen-sink.yml
+++ b/.github/workflows/kitchen-sink.yml
@@ -36,7 +36,7 @@ jobs:
           sudo chown -R 1000:1000 ./cypress
 
       - name: Run kitchen sink test
-        use: saucelabs/saucectl-run-action@v1
+        uses: saucelabs/saucectl-run-action@v1
         with:
           working-directory: ./tests/kitchen-sink-tests
           sauce-username: ${{ secrets.SAUCE_USERNAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,12 @@ jobs:
           build-args: |
             BUILD_TAG=pipeline-test
 
+      # Run tests
+      - name: Run integration tests
+        run: bash ./tests/integration-test.sh
+        env:
+          SKIP_CI: true
+
   build-ubuntu-bundle-and-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,6 @@ jobs:
           build-args: |
             BUILD_TAG=pipeline-test
 
-      # Run tests
-      - name: Run integration tests
-        run: bash ./tests/integration-test.sh
-        env:
-          SKIP_CI: true
-
   build-ubuntu-bundle-and-test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Use github action `saucectl-run-action` to  run tests instead of installing manually `saucectl`.