### PR TITLE
CI: support restarting pipeline with no side-effects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
 
           $selectedAsset = $null
           Foreach ($asset in $selectedRelease.assets) {
-            if ($asset.name -eq "sauce-cypress-win.zip") {
+            if ($asset.name -eq "sauce-cypress-runner.zip") {
               $selectedAsset = $asset
             }
           }
@@ -197,7 +197,7 @@ jobs:
         uses: azure/powershell@v1
         with:
           inlineScript: |
-            Compress-Archive bundle/ sauce-cypress-win.zip
+            Compress-Archive bundle/ sauce-cypress-runner.zip
           azPSVersion: '3.1.0'
 
       - name: Upload Release Asset
@@ -208,8 +208,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }}/assets?name=sauce-cypress-runner.zip
-          asset_path: ./sauce-cypress-win.zip
-          asset_name: sauce-cypress-win.zip
+          asset_path: ./sauce-cypress-runner.zip
+          asset_name: sauce-cypress-runner.zip
           asset_content_type: application/zip
 
   release-template-bundle:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,25 +16,46 @@ jobs:
   create-release-draft:
     runs-on: ubuntu-latest
     steps:
+      - name: Check tag
+        id: prep
+        run: |
+          TAG_NAME=$(curl -s -H "Authorization: token ${{ github.token }}" \
+                      https://api.github.com/repos/${{ github.repository }}/releases | \
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .tag_name | select (. != null)")
+          IS_DRAFT=$(curl -s -H "Authorization: token ${{ github.token }}" \
+                      https://api.github.com/repos/${{ github.repository }}/releases | \
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .draft | select (. != null)")
+
+          if [ -n "${TAG_NAME}" ] && [ "${IS_DRAFT}" == "false" ];then
+              echo "A release has already been published for this run_id (${{ github.run_id }} / ${TAG_NAME})."
+              exit 1
+          fi
+          echo ::set-output name=tag_name::${TAG_NAME}
+
       - uses: actions/checkout@v2
+        if: ${{ steps.prep.outputs.tag_name == '' }}
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Setup Node version
+        if: ${{ steps.prep.outputs.tag_name == '' }}
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
 
       - name: Setup Git
+        if: ${{ steps.prep.outputs.tag_name == '' }}
         run: |
           git config --global user.name "devx-sauce-bot"
           git config --global user.email "devx.bot@saucelabs.com"
 
       - name: Install dependencies
+        if: ${{ steps.prep.outputs.tag_name == '' }}
         run: npm ci
 
       - name: generate (pre-)release draft
+        if: ${{ steps.prep.outputs.tag_name == '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -128,35 +149,51 @@ jobs:
               exit 1
           }
 
+          $selectedAsset = $null
+          Foreach ($asset in $selectedRelease.assets) {
+            if ($asset.name -eq "sauce-cypress-win.zip") {
+              $selectedAsset = $asset
+            }
+          }
+
           $tagName = $selectedRelease.tag_name
           $releaseId = $selectedRelease.id
+          $assetId = $selectedAsset.id
           Write-Output "::set-output name=version::$tagName"
           Write-Output "::set-output name=release_id::$releaseId"
+          Write-Output "::set-output name=asset_id::$assetId"
 
-      - run: Write-Output "${{ steps.prep.outputs.release_id }} - ${{  steps.prep.outputs.version }}"
+      - run: Write-Output "${{ steps.prep.outputs.release_id }} - ${{ steps.prep.outputs.version }} - ${{ steps.prep.outputs.asset_id }}"
 
       - uses: actions/checkout@v2
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         with:
           ref: ${{ steps.prep.outputs.version }}
 
       - name: Use Node.js v14.x
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
 
       - name: Update Release version
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: |
           npm version --no-git-tag-version ${{  steps.prep.outputs.version }}
 
       - run: npm ci --production
+        if: ${{ steps.prep.outputs.asset_id == '' }}
 
       - name: Bundle Directory
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: bash ./scripts/bundle.sh
 
       - name: List bundle contents
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: ls -R bundle/
 
       - name: Archive bundle
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: azure/powershell@v1
         with:
           inlineScript: |
@@ -164,6 +201,7 @@ jobs:
           azPSVersion: '3.1.0'
 
       - name: Upload Release Asset
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
@@ -192,30 +230,41 @@ jobs:
               echo "No draft version found"
               exit 1
           fi
+
+          ASSET_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
+                      https://api.github.com/repos/${{ github.repository }}/releases | \
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .assets | .[] | select(.name == \"saucetpl.tar.gz\") | .id | select(. != null)")
+
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=release_id::${RELEASE_ID}
+          echo ::set-output name=asset_id::${ASSET_ID}
 
-      - run: echo "${{ steps.prep.outputs.release_id }} - ${{  steps.prep.outputs.version }}"
+      - run: echo "${{ steps.prep.outputs.release_id }} - ${{ steps.prep.outputs.version }} - ${{ steps.prep.outputs.asset_id }}"
 
       - uses: actions/checkout@v2
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         with:
           ref: ${{ steps.prep.outputs.version }}
 
       - name: Use Node.js v14.x
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
 
       - name: Update Release version
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: |
           npm version --no-git-tag-version ${{  steps.prep.outputs.version }}
           CYPRESS_VERSION=`< package-lock.json  jq -r '.dependencies["cypress"].version'`
           sed -i "s/##VERSION##/${CYPRESS_VERSION}/g" .saucetpl/.sauce/config.yml
 
       - name: Archive template
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: cd .saucetpl && tar -czf ../saucetpl.tar.gz .
 
       - name: Upload Template Asset
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
       - uses: saucelabs/saucectl-run-action@v1
         with:
           skip-run: true
+          testing-environment: docker
 
       # There is discrepencies between uid used to clone and uid in container,
       # As a temporary measure, we chmod files to allow test outputs to be written.
@@ -78,7 +79,7 @@ jobs:
           cd .saucetpl
           yq e -i '.docker.image = "saucelabs/stt-cypress-mocha-node:local"' .sauce/config.yml
           yq e -i '.cypress.version = "latest"' .sauce/config.yml
-          saucectl run
+          saucectl run --test-env docker
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}


### PR DESCRIPTION
- Check for existing tag/release associated with current pipeline
- Avoid rebuilding templates/bundles
- Generate error if already publish
