### PR TITLE
Slack failed post release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,10 +309,45 @@ jobs:
       - uses: actions/checkout@master
       - name: Install Deps
         run: npm ci
-      - name: cloud tests
-        working-directory: ./tests/kitchen-sink-tests
+      - name: Parse release version
+        id: parse_version
         run: |
           VERSION=$(curl -s -H "Authorization: token ${{ github.token }}" \
                       https://api.github.com/repos/${{ github.repository }}/releases | \
                       jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .tag_name")
-          npx saucectl run --test-env sauce --ccy 5 --region us-west-1 --runner-version "github-release: ${VERSION}"
+          echo ::set-output name=version::${VERSION}
+
+      - name: cloud tests
+        working-directory: ./tests/kitchen-sink-tests
+        run: |
+          npx saucectl run --test-env sauce --ccy 5 --region us-west-1 --runner-version "github-release: ${{ steps.parse_version.outputs.version }}"
+
+      - name: Notify slack on failure
+        uses: 8398a7/action-slack@v3
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          RELEASE: ${{ steps.parse_version.outputs.version }}
+        with:
+          status: custom
+          fields: commit,workflow,job
+          custom_payload: |
+            {
+              attachments: [{
+                mrkdwn_in: ['text'],
+                title: `${{ github.repository }}@${process.env.RELEASE}`,
+                title_link: `https://github.com/${{ github.repository }}/releases/${process.env.RELEASE}`,
+                text: `${process.env.AS_JOB} job failed  :homer_back_away:`,
+                color: 'danger',
+                fields: [{
+                  title: 'Commit',
+                  value: `${process.env.AS_COMMIT}`,
+                  short: true
+                },
+                {
+                  title: 'Workflow',
+                  value: `${process.env.AS_WORKFLOW}`,
+                  short: true
+                }]
+              }]
+            }


### PR DESCRIPTION
Post to slack if post-release job fails.

Realized the message should make it more clear which runner has failed, so message format is different from https://github.com/saucelabs/sauce-testcafe-runner/pull/72

![Screen Shot 2021-03-22 at 4 40 21 PM](https://user-images.githubusercontent.com/56001373/112067545-d64b9980-8b2d-11eb-80ef-8ecd95685110.png)

I'll update the message from testcafe-runner to make things consistent.
