### PR TITLE
Bump testrunner-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12960,9 +12960,9 @@
       }
     },
     "sauce-testrunner-utils": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/sauce-testrunner-utils/-/sauce-testrunner-utils-0.4.2.tgz",
-      "integrity": "sha512-M5zRssQJED0mJ2hR7cDUCdQ4ER4K0TSFz8OJHgQIoBf96aJtjVcQ2zr8saXDBxnflMHuswmojMaKLAFlLIPt3A==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/sauce-testrunner-utils/-/sauce-testrunner-utils-0.4.4.tgz",
+      "integrity": "sha512-o1UGLk/ytIzHuidssx4ZvurP8N5xUbTm4eVa5eN2uK3e6YpA5JZhyJkyA5YPcKg9H2wcDfuheG9aPf/az76u1A==",
       "requires": {
         "lodash": "^4.17.20",
         "npm": "^6.14.9"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lodash": "^4.17.20",
     "mocha-junit-reporter": "^2.0.0",
     "npm": "^6.14.9",
-    "sauce-testrunner-utils": "0.4.2",
+    "sauce-testrunner-utils": "0.4.4",
     "saucelabs": "4.7.5",
     "smart-buffer": "^4.1.0",
     "typescript": "^3.9.7",


### PR DESCRIPTION
0.4.4 has a fix for how `npm install` behaves if there is a `package-lock.json` in the cwd.