### PR TITLE
[DEVX-1136] Don't rename assets on upload

### DIFF
--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -6,7 +6,6 @@ const _ = require('lodash');
 const ffmpeg = require('fluent-ffmpeg');
 const { promisify } = require('util');
 const ffprobe = promisify(ffmpeg.ffprobe);
-const utils = require('sauce-testrunner-utils');
 const { updateExportedValue } = require('sauce-testrunner-utils').saucectl;
 const { shouldRecordVideo } = require('sauce-testrunner-utils');
 const convert = require('xml-js');
@@ -150,8 +149,6 @@ SauceReporter.prepareAssets = async (specFiles, resultsFolder, metrics, testName
       const screenshotPaths = fs.readdirSync(screenshotsFolder);
       screenshotPaths.forEach((file) => {
         let screenshot = path.join(screenshotsFolder, file);
-        // rename screenshots to allow uploading screenshots with the same name but different folders
-        screenshot = utils.renameScreenshot(specFile, screenshot, resultsFolder, path.basename(file));
         assets.push(screenshot);
       });
     }
@@ -164,8 +161,6 @@ SauceReporter.prepareAssets = async (specFiles, resultsFolder, metrics, testName
         }
         continue;
       }
-      // rename assets to allow uploading assets with the same name but different folders
-      assetFile = utils.renameAsset({specFile: asset.name, oldFilePath: assetFile, resultsFolder});
       assets.push(assetFile);
 
       if (asset.name.endsWith('.mp4')) {

--- a/tests/unit/src/__snapshots__/sauce-reporter.spec.js.snap
+++ b/tests/unit/src/__snapshots__/sauce-reporter.spec.js.snap
@@ -11,11 +11,11 @@ Array [
 exports[`SauceReporter .prepareAssets should return a list of assets 2`] = `
 Array [
   "console.log",
-  "results/spec__file.test.js__screenshot-1.png",
-  "results/spec__file.test.js__screenshot-2.png",
-  "results/spec__file.test.js.mp4",
-  "results/spec__file.test.js.json",
-  "results/spec__file.test.js.xml",
+  "results/spec/file.test.js/fake/path/to/screenshot-1.png",
+  "results/spec/file.test.js/fake/path/to/screenshot-2.png",
+  "results/spec/file.test.js.mp4",
+  "results/spec/file.test.js.json",
+  "results/spec/file.test.js.xml",
   "results/video.mp4",
   "results/junit.xml",
 ]


### PR DESCRIPTION
Don't rename assets on upload. Proved to be not really necessary and visually even harder to comprehend.