### PR TITLE
[DEVX-1465] Move headless configuration to one level above

### DIFF
--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -102,6 +102,7 @@ const getCypressOpts = function (runCfg, suiteName) {
   const cypressCfg = JSON.parse(fs.readFileSync(cypressCfgFile, 'utf8'));
 
   let headed = true;
+  // suite.config.headless is kepts to keep backward compatibility.
   if (suite.headless || suite.config.headless) {
     headed = false;
   }

--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -102,7 +102,7 @@ const getCypressOpts = function (runCfg, suiteName) {
   const cypressCfg = JSON.parse(fs.readFileSync(cypressCfgFile, 'utf8'));
 
   let headed = true;
-  if (suite.headless) {
+  if (suite.headless || suite.config.headless) {
     headed = false;
   }
 

--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -102,7 +102,7 @@ const getCypressOpts = function (runCfg, suiteName) {
   const cypressCfg = JSON.parse(fs.readFileSync(cypressCfgFile, 'utf8'));
 
   let headed = true;
-  if (suite.config.headless) {
+  if (suite.headless) {
     headed = false;
   }
 


### PR DESCRIPTION
Move `headless` as part of `suite` instead of `suite.config`.

`suite.config` left for compatibility.