### PR TITLE
[DEVX-1532] Inject env vars to process.env before invoking Cypress

### DIFF
--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -94,7 +94,7 @@ const configureReporters = function (cypressCfg, runCfg, opts) {
   return opts;
 };
 
-const pickSuite = function (runCfg, suiteName) {
+const getSuite = function (runCfg, suiteName) {
   const suites = runCfg.suites || [];
   const suite = suites.find((testSuite) => testSuite.name === suiteName);
   if (!suite) {
@@ -105,7 +105,7 @@ const pickSuite = function (runCfg, suiteName) {
 };
 
 const setEnvironmentVariables = function (runCfg, suiteName) {
-  const suite = pickSuite(runCfg, suiteName);
+  const suite = getSuite(runCfg, suiteName);
   const envVars = getEnv(suite);
 
   for (const [key, value] of Object.entries(envVars)) {
@@ -115,7 +115,7 @@ const setEnvironmentVariables = function (runCfg, suiteName) {
 
 const getCypressOpts = function (runCfg, suiteName) {
   // Get user settings from suites.
-  const suite = pickSuite(runCfg, suiteName);
+  const suite = getSuite(runCfg, suiteName);
   const projectDir = path.dirname(getAbsolutePath(runCfg.path));
 
   let cypressCfgFile = path.join(projectDir, runCfg.cypress.configFile);
@@ -225,5 +225,5 @@ if (require.main === module) {
 
 exports.cypressRunner = cypressRunner;
 exports.configureReporters = configureReporters;
-exports.pickSuite = pickSuite;
+exports.getSuite = getSuite;
 exports.setEnvironmentVariables = setEnvironmentVariables;

--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -94,15 +94,28 @@ const configureReporters = function (cypressCfg, runCfg, opts) {
   return opts;
 };
 
-const getCypressOpts = function (runCfg, suiteName) {
-  // Get user settings from suites.
+const pickSuite = function (runCfg, suiteName) {
   const suites = runCfg.suites || [];
   const suite = suites.find((testSuite) => testSuite.name === suiteName);
   if (!suite) {
     const suiteNames = suites.map((suite) => suite.name);
-    throw new Error(`Could not find suite named '${suiteName}'; available suites='${JSON.stringify(suiteNames)}`);
+    throw new Error(`Could not find suite named '${suiteName}'; available suites=${JSON.stringify(suiteNames)}`);
   }
+  return suite;
+};
 
+const setEnvironmentVariables = function (runCfg, suiteName) {
+  const suite = pickSuite(runCfg, suiteName);
+  const envVars = getEnv(suite);
+
+  for (const [key, value] of Object.entries(envVars)) {
+    process.env[key] = value;
+  }
+};
+
+const getCypressOpts = function (runCfg, suiteName) {
+  // Get user settings from suites.
+  const suite = pickSuite(runCfg, suiteName);
   const projectDir = path.dirname(getAbsolutePath(runCfg.path));
 
   let cypressCfgFile = path.join(projectDir, runCfg.cypress.configFile);
@@ -172,6 +185,9 @@ const cypressRunner = async function (runCfgPath, suiteName, timeoutSec) {
   let startTime = new Date().toISOString();
   const suites = runCfg.suites || [];
   const suite = suites.find((testSuite) => testSuite.name === suiteName);
+
+  setEnvironmentVariables(runCfg, suiteName);
+
   // saucectl suite.timeout is in nanoseconds
   timeoutSec = suite.timeout / 1000000000 || timeoutSec;
   let timeout;
@@ -209,3 +225,5 @@ if (require.main === module) {
 
 exports.cypressRunner = cypressRunner;
 exports.configureReporters = configureReporters;
+exports.pickSuite = pickSuite;
+exports.setEnvironmentVariables = setEnvironmentVariables;

--- a/tests/unit/src/cypress-runner.spec.js
+++ b/tests/unit/src/cypress-runner.spec.js
@@ -18,7 +18,7 @@ const cypress = require('cypress');
 const path = require('path');
 const fs = require('fs');
 const SauceReporter = require('../../../src/sauce-reporter');
-const { cypressRunner, setEnvironmentVariables, pickSuite } = require('../../../src/cypress-runner');
+const { cypressRunner, setEnvironmentVariables, getSuite } = require('../../../src/cypress-runner');
 const {afterRunTestReport} = require('@saucelabs/cypress-plugin');
 
 describe('.cypressRunner', function () {
@@ -132,16 +132,16 @@ describe('.cypressRunner', function () {
     });
   });
 
-  describe('.pickSuite', function () {
+  describe('.getSuite', function () {
     it('select the correct suite', function () {
       const runCfg = utils.loadRunConfig('/fake/path');
-      const suite = pickSuite(runCfg, 'fake-suite');
+      const suite = getSuite(runCfg, 'fake-suite');
       expect(suite).toEqual(runCfg.suites[0]);
     });
     it('fails when not found', function () {
       const t = () => {
         const runCfg = utils.loadRunConfig('/fake/path');
-        pickSuite(runCfg, 'non-existant');
+        getSuite(runCfg, 'non-existant');
       };
       expect(t).toThrow(`Could not find suite named 'non-existant'; available suites=["fake-suite"]`);
     });

--- a/tests/unit/src/cypress-runner.spec.js
+++ b/tests/unit/src/cypress-runner.spec.js
@@ -1,22 +1,31 @@
 jest.mock('cypress');
 jest.mock('fs');
-jest.mock('sauce-testrunner-utils');
+jest.mock('sauce-testrunner-utils', () => {
+  const original = jest.requireActual('sauce-testrunner-utils');
+  const mocked = Object.fromEntries(Object.keys(original).map(function (k) { return [k, jest.fn()]; }));
+
+  return {
+    ...mocked,
+    getEnv: original.getEnv,
+  };
+});
 jest.mock('../../../src/sauce-reporter');
 jest.mock('@saucelabs/cypress-plugin');
 
 const utils = require('sauce-testrunner-utils');
-const { loadRunConfig, getAbsolutePath } = require('sauce-testrunner-utils');
+const { getAbsolutePath, loadRunConfig } = require('sauce-testrunner-utils');
 const cypress = require('cypress');
 const path = require('path');
 const fs = require('fs');
 const SauceReporter = require('../../../src/sauce-reporter');
-const { cypressRunner } = require('../../../src/cypress-runner');
+const { cypressRunner, setEnvironmentVariables, pickSuite } = require('../../../src/cypress-runner');
 const {afterRunTestReport} = require('@saucelabs/cypress-plugin');
 
 describe('.cypressRunner', function () {
   let oldEnv = { ...process.env };
   let cypressRunSpy;
   cypressRunSpy = jest.spyOn(cypress, 'run');
+
   beforeEach(function () {
     process.env = { ...oldEnv };
     cypressRunSpy.mockClear();
@@ -49,9 +58,11 @@ describe('.cypressRunner', function () {
     let day = 0;
     isoDateSpy.mockImplementation(() => `Date: ${++day}`);
   });
+
   afterEach(function () {
     SauceReporter.sauceReporter.mockReset();
   });
+
   it('returns failure if Cypress.run is called with a timeout of 0 (Docker mode)', async function () {
     const run = new Promise((resolve) => {
       setTimeout(resolve, 10);
@@ -85,10 +96,12 @@ describe('.cypressRunner', function () {
     await cypressRunner('/fake/runner/path', 'fake-suite', 1);
     expect(SauceReporter.sauceReporter.mock.calls).toMatchSnapshot();
   });
+
   describe('from SAUCE VM', function () {
     beforeEach(function () {
       process.env.SAUCE_VM = 'truthy';
     });
+
     it('returns false if there are test failures', async function () {
       cypressRunSpy.mockImplementation(() => ({failures: 100}));
       const status = await cypressRunner('/fake/runner/path', 'fake-suite', 1);
@@ -116,6 +129,62 @@ describe('.cypressRunner', function () {
       cypress.run.mockImplementation(() => run);
       const status = await cypressRunner('/fake/runner/path', 'fake-suite', 1);
       expect(status).toEqual(false);
+    });
+  });
+
+  describe('.pickSuite', function () {
+    it('select the correct suite', function () {
+      const runCfg = utils.loadRunConfig('/fake/path');
+      const suite = pickSuite(runCfg, 'fake-suite');
+      expect(suite).toEqual(runCfg.suites[0]);
+    });
+    it('fails when not found', function () {
+      const t = () => {
+        const runCfg = utils.loadRunConfig('/fake/path');
+        pickSuite(runCfg, 'non-existant');
+      };
+      expect(t).toThrow(`Could not find suite named 'non-existant'; available suites=["fake-suite"]`);
+    });
+  });
+
+  describe('.setEnvironmentVariable', function () {
+    const oldEnv = process.env;
+
+    beforeEach(function () {
+      process.env = { ...oldEnv };
+    });
+
+    it('empty environment - does not explode', function () {
+      const runCfg = utils.loadRunConfig('/fake/path');
+      runCfg.suites[0].config.env = {};
+      runCfg.suites[0].env = {};
+      setEnvironmentVariables(runCfg, runCfg.suites[0].name);
+    });
+
+    it('With some vars', function () {
+      const runCfg = utils.loadRunConfig('/fake/path');
+      setEnvironmentVariables(runCfg, runCfg.suites[0].name);
+
+      expect(process.env).toEqual(
+        expect.objectContaining({
+          ...runCfg.suites[0].env,
+          ...runCfg.suites[0].config.env,
+        }));
+    });
+
+    it('With some vars + resolution', function () {
+      const runCfg = utils.loadRunConfig('/fake/path');
+      process.env.EXTRA_VAR = 'hello';
+      runCfg.suites[0].config.env.OUTSIDE_VAR = '$EXTRA_VAR';
+
+      setEnvironmentVariables(runCfg, runCfg.suites[0].name);
+
+      expect(process.env).toEqual(
+        expect.objectContaining({
+          ...runCfg.suites[0].env,
+          ...runCfg.suites[0].config.env,
+          OUTSIDE_VAR: 'hello',
+        }));
     });
   });
 });


### PR DESCRIPTION
Most of plugins relies on `process.env` as Cypress does not provides access to its internal env vars.
This MR registers env vars to the system before invoking Cypress to make them available to the plugins (or any other usages).

Also adds some changes to the tests.

Example run on Docker: https://app.saucelabs.com/tests/c294435558234f6195bd2ee376a841cf