### PR TITLE
[DEVX-1626] improve error handling for generating junit file

### DIFF
--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -322,72 +322,69 @@ SauceReporter.mergeJunitFile = (specFiles, resultsFolder, testName, browserName,
   try {
     const xmlData = fs.readFileSync(path.join(resultsFolder, `${specFiles[0]}.xml`), 'utf8');
     result = convert.xml2js(xmlData, opts);
-  } catch (err) {
-    console.error(err);
-  }
-  for (let i = 1; i < specFiles.length; i++) {
-    let jsObj;
-    try {
+    for (let i = 1; i < specFiles.length; i++) {
+      let jsObj;
       const xmlData = fs.readFileSync(path.join(resultsFolder, `${specFiles[i]}.xml`), 'utf8');
       jsObj = convert.xml2js(xmlData, opts);
-    } catch (err) {
-      console.error(err);
+      result.testsuites.testsuite.push(...jsObj.testsuites.testsuite);
     }
-    result.testsuites.testsuite.push(...jsObj.testsuites.testsuite);
-  }
 
-  for (let ts of result.testsuites.testsuite) {
-    totalTests += +ts._attributes.tests || 0;
-    totalFailure += +ts._attributes.failures || 0;
-    totalTime += +ts._attributes.time || 0.0000;
-    totalErr += +ts._attributes.error || 0;
-    totalDisabled += +ts._attributes.disabled || 0;
-  }
-  result.testsuites._attributes.name = testName;
-  result.testsuites._attributes.tests = totalTests;
-  result.testsuites._attributes.failures = totalFailure;
-  result.testsuites._attributes.time = totalTime;
-  result.testsuites._attributes.error = totalErr;
-  result.testsuites._attributes.disabled = totalDisabled;
-  result.testsuites.testsuite = result.testsuites.testsuite.filter((item) => item._attributes.name !== 'Root Suite');
-  if (process.platform.toLowerCase() === 'linux') {
-    platformName = 'Linux';
-  }
-  const browsers = browserName.split(':');
-  if (browsers.length > 0) {
-    browserName = browsers[browsers.length - 1];
-  }
-  for (let i = 0; i < result.testsuites.testsuite.length; i++) {
-    const testcase = result.testsuites.testsuite[i].testcase;
-    result.testsuites.testsuite[i]._attributes.id = i;
-    result.testsuites.testsuite[i].properties = {};
-    if (testcase && testcase.failure) {
-      result.testsuites.testsuite[i].testcase.failure._attributes.message = escapeXML(testcase.failure._attributes.message || '');
-      result.testsuites.testsuite[i].testcase.failure._attributes.type = testcase.failure._attributes.type || '';
-      result.testsuites.testsuite[i].testcase.failure._cdata = testcase.failure._cdata || '';
+    if (!result.testsuites || !result.testsuites.testsuite) {
+      return;
     }
-    result.testsuites.testsuite[i].properties.property = [
 
-      {
-        _attributes: {
-          name: 'platformName',
-          value: platformName,
-        }
-      },
-      {
-        _attributes: {
-          name: 'browserName',
-          value: browserName,
-        }
+    for (let ts of result.testsuites?.testsuite) {
+      totalTests += +ts._attributes.tests || 0;
+      totalFailure += +ts._attributes.failures || 0;
+      totalTime += +ts._attributes.time || 0.0000;
+      totalErr += +ts._attributes.error || 0;
+      totalDisabled += +ts._attributes.disabled || 0;
+    }
+    result.testsuites._attributes.name = testName;
+    result.testsuites._attributes.tests = totalTests;
+    result.testsuites._attributes.failures = totalFailure;
+    result.testsuites._attributes.time = totalTime;
+    result.testsuites._attributes.error = totalErr;
+    result.testsuites._attributes.disabled = totalDisabled;
+    result.testsuites.testsuite = result.testsuites.testsuite.filter((item) => item._attributes.name !== 'Root Suite');
+    if (process.platform.toLowerCase() === 'linux') {
+      platformName = 'Linux';
+    }
+    const browsers = browserName.split(':');
+    if (browsers.length > 0) {
+      browserName = browsers[browsers.length - 1];
+    }
+    for (let i = 0; i < result.testsuites.testsuite.length; i++) {
+      const testcase = result.testsuites.testsuite[i].testcase;
+      result.testsuites.testsuite[i]._attributes.id = i;
+      result.testsuites.testsuite[i].properties = {};
+      if (testcase && testcase.failure) {
+        result.testsuites.testsuite[i].testcase.failure._attributes.message = escapeXML(testcase.failure._attributes.message || '');
+        result.testsuites.testsuite[i].testcase.failure._attributes.type = testcase.failure._attributes.type || '';
+        result.testsuites.testsuite[i].testcase.failure._cdata = testcase.failure._cdata || '';
       }
-    ];
-  }
-  try {
+      result.testsuites.testsuite[i].properties.property = [
+
+        {
+          _attributes: {
+            name: 'platformName',
+            value: platformName,
+          }
+        },
+        {
+          _attributes: {
+            name: 'browserName',
+            value: browserName,
+          }
+        }
+      ];
+    }
+
     opts.textFn = escapeXML;
     let xmlResult = convert.js2xml(result, opts);
     fs.writeFileSync(path.join(resultsFolder, 'junit.xml'), xmlResult);
   } catch (err) {
-    console.error(err);
+    console.error('failed to generate junit file:', err);
   }
 };
 

--- a/src/sauce-reporter.js
+++ b/src/sauce-reporter.js
@@ -363,9 +363,7 @@ SauceReporter.mergeJunitFile = (specFiles, resultsFolder, testName, browserName,
     const testcase = result.testsuites.testsuite[i].testcase;
 
     // _attributes
-    if (!result.testsuites.testsuite[i]._attributes) {
-      result.testsuites.testsuite[i]._attributes = {};
-    }
+    result.testsuites.testsuite[i]._attributes = result.testsuites.testsuite[i]._attributes || {};
     result.testsuites.testsuite[i]._attributes.id = i;
 
     // failure message


### PR DESCRIPTION
If there were an error, it'd be handled like this
```
failed to generate junit file: TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at Object.SauceReporter.mergeJunitFile (/home/seluser/src/sauce-reporter.js:332:37)
    at SauceReporter.prepareAssets (/home/seluser/src/sauce-reporter.js:136:17)
    at report (/home/seluser/src/cypress-runner.js:24:22)
    at cypressRunner (/home/seluser/src/cypress-runner.js:206:16)
Using /home/seluser/__project__/__assets__/examples/1.spec.js.mp4 as the main video.

Open job details page: https://app.saucelabs.com/tests/1a01da1c215448b0bb18b1844ca34ada

 suite="Chrome using global mode setting"


  Results:


       Name                                Duration    Status    Browser                 Platform    Attempts
───────────────────────────────────────────────────────────────────────────────────────────────────────────────
  ✔    Chrome using global mode setting         37s    passed    chrome 92.0.4515.159    Docker             0
───────────────────────────────────────────────────────────────────────────────────────────────────────────────
  ✔    All tests have passed                    38s
```