### PR TITLE
[DEVX-1637] Standardize release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,18 +203,28 @@ jobs:
         uses: azure/powershell@v1
         with:
           inlineScript: |
-            Compress-Archive bundle/ sauce-cypress-runner.zip
+            Compress-Archive bundle/ sauce-cypress-runner-win-amd64.zip
           azPSVersion: '3.1.0'
 
       - name: Upload Release Asset
         if: ${{ steps.prep.outputs.asset_id == '' }}
-        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }}/assets?name=sauce-cypress-runner-win-amd64.zip
+          asset_path: ./sauce-cypress-runner-win-amd64.zip
+          asset_name: sauce-cypress-runner-win-amd64.zip
+          asset_content_type: application/zip
+
+      - name: Upload Release Asset Legacy
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }}/assets?name=sauce-cypress-runner.zip
-          asset_path: ./sauce-cypress-runner.zip
+          asset_path: ./sauce-cypress-runner-win-amd64.zip
           asset_name: sauce-cypress-runner.zip
           asset_content_type: application/zip
 
@@ -276,17 +286,27 @@ jobs:
 
       - name: Archive bundle
         if: ${{ steps.prep.outputs.asset_id == '' }}
-        run: zip -r sauce-cypress-macos.zip bundle/
+        run: zip -r sauce-cypress-macos-amd64.zip bundle/
 
       - name: Upload Release Asset
         if: ${{ steps.prep.outputs.asset_id == '' }}
-        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }}/assets?name=sauce-cypress-macos-amd64.zip
+          asset_path: ./sauce-cypress-macos-amd64.zip
+          asset_name: sauce-cypress-macos-amd64.zip
+          asset_content_type: application/zip
+
+      - name: Upload Release Asset Legacy
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }}/assets?name=sauce-cypress-macos.zip
-          asset_path: ./sauce-cypress-macos.zip
+          asset_path: ./sauce-cypress-macos-amd64.zip
           asset_name: sauce-cypress-macos.zip
           asset_content_type: application/zip
 


### PR DESCRIPTION
Standardize release assets according to the new format: `{framework}-{os}-{arch}.zip`

This change does not replace legacy assets. At least not until all images are built using the new assets.
