### PR TITLE
Remove unnecessary config copy

### DIFF
--- a/src/cypress-runner.js
+++ b/src/cypress-runner.js
@@ -163,7 +163,6 @@ const getCypressOpts = function (runCfg, suiteName) {
 
   opts = configureReporters(runCfg, opts);
 
-  _.defaultsDeep(opts.config, suite.config);
   return opts;
 };
 


### PR DESCRIPTION
Notice this warning msg for cypress 10
```
The following configuration option is invalid:

 - testingType
```
It's because of unnecessary config copy for `cypress.run()` and the result is like
```
cypressOpts:  {
  testingType: 'e2e',
  config: {
    specPattern: [ 'cypress/e2e/**/*.js' ],
    excludeSpecPattern: [],
    ...
    testingType: 'e2e'
  }
}
```
cypress throws warning for the nested `testingType` under `config`