### PR TITLE
Override get-port library

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,10 @@ jobs:
       - name: Bundle Directory
         run: bash ./scripts/bundle.sh
 
+      - name: Override Dependencies
+        run: npm i get-port@6.1.2 --no-save
+        working-directory: bundle/cache/10.7.0/Cypress/resources/app/node_modules
+
       - name: Archive bundle
         uses: azure/powershell@v1
         with:
@@ -142,6 +146,10 @@ jobs:
 
       - name: Bundle Directory
         run: bash ./scripts/bundle.sh
+
+      - name: Override Dependencies
+        run: npm i get-port@6.1.2 --no-save
+        working-directory: bundle/cache/10.7.0/Cypress.app/Contents/Resources/app/node_modules
 
       - name: Archive bundle
         run: zip --symlinks -r sauce-cypress-macos.zip bundle/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,8 +73,9 @@ jobs:
         run: bash ./scripts/bundle.sh
 
       - name: Override Dependencies
-        run: npm i get-port@6.1.2 --no-save
-        working-directory: bundle/cache/10.7.0/Cypress/resources/app/node_modules
+        run: | 
+          rm -r bundle/cache/10.7.0/Cypress/resources/app/node_modules/get-port
+          cp -r vendor/get-port bundle/cache/10.7.0/Cypress/resources/app/node_modules
 
       - name: Archive bundle
         uses: azure/powershell@v1
@@ -148,8 +149,9 @@ jobs:
         run: bash ./scripts/bundle.sh
 
       - name: Override Dependencies
-        run: npm i get-port@6.1.2 --no-save
-        working-directory: bundle/cache/10.7.0/Cypress.app/Contents/Resources/app/node_modules
+        run: |
+          rm -r bundle/cache/10.7.0/Cypress.app/Contents/Resources/app/node_modules/get-port
+          cp -r vendor/get-port bundle/cache/10.7.0/Cypress.app/Contents/Resources/app/node_modules
 
       - name: Archive bundle
         run: zip --symlinks -r sauce-cypress-macos.zip bundle/

--- a/package-lock.json
+++ b/package-lock.json
@@ -15200,7 +15200,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -15215,19 +15214,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15241,7 +15237,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -15257,7 +15252,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -30714,8 +30708,7 @@
             },
             "lodash._baseindexof": {
               "version": "3.1.0",
-              "bundled": true,
-              "extraneous": true
+              "bundled": true
             },
             "lodash._baseuniq": {
               "version": "4.6.0",
@@ -30727,18 +30720,15 @@
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "bundled": true,
-              "extraneous": true
+              "bundled": true
             },
             "lodash._cacheindexof": {
               "version": "3.0.2",
-              "bundled": true,
-              "extraneous": true
+              "bundled": true
             },
             "lodash._createcache": {
               "version": "3.1.2",
               "bundled": true,
-              "extraneous": true,
               "requires": {
                 "lodash._getnative": "^3.0.0"
               }
@@ -30749,8 +30739,7 @@
             },
             "lodash._getnative": {
               "version": "3.9.1",
-              "bundled": true,
-              "extraneous": true
+              "bundled": true
             },
             "lodash._root": {
               "version": "3.0.1",
@@ -30762,8 +30751,7 @@
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "bundled": true,
-              "extraneous": true
+              "bundled": true
             },
             "lodash.union": {
               "version": "4.6.0",

--- a/vendor/get-port/index.d.ts
+++ b/vendor/get-port/index.d.ts
@@ -1,0 +1,62 @@
+import {ListenOptions} from 'node:net';
+
+export interface Options extends Omit<ListenOptions, 'port'> {
+	/**
+	A preferred port or an iterable of preferred ports to use.
+	*/
+	readonly port?: number | Iterable<number>;
+
+	/**
+	Ports that should not be returned.
+
+	You could, for example, pass it the return value of the `portNumbers()` function.
+	*/
+	readonly exclude?: Iterable<number>;
+
+	/**
+	The host on which port resolution should be performed. Can be either an IPv4 or IPv6 address.
+
+	By default, it checks availability on all local addresses defined in [OS network interfaces](https://nodejs.org/api/os.html#os_os_networkinterfaces). If this option is set, it will only check the given host.
+	*/
+	readonly host?: string;
+}
+
+/**
+Get an available TCP port number.
+
+@returns Port number.
+
+@example
+```
+import getPort from 'get-port';
+
+console.log(await getPort());
+//=> 51402
+
+// Pass in a preferred port
+console.log(await getPort({port: 3000}));
+// Will use 3000 if available, otherwise fall back to a random port
+
+// Pass in an array of preferred ports
+console.log(await getPort({port: [3000, 3001, 3002]}));
+// Will use any element in the preferred ports array if available, otherwise fall back to a random port
+```
+*/
+export default function getPort(options?: Options): Promise<number>;
+
+/**
+Generate port numbers in the given range `from`...`to`.
+
+@param from - The first port of the range. Must be in the range `1024`...`65535`.
+@param to - The last port of the range. Must be in the range `1024`...`65535` and must be greater than `from`.
+@returns The port numbers in the range.
+
+@example
+```
+import getPort, {portNumbers} from 'get-port';
+
+console.log(await getPort({port: portNumbers(3000, 3100)}));
+// Will use any port from 3000 to 3100, otherwise fall back to a random port
+```
+*/
+export function portNumbers(from: number, to: number): Iterable<number>;

--- a/vendor/get-port/index.js
+++ b/vendor/get-port/index.js
@@ -1,0 +1,179 @@
+'strict';
+const net = require('node:net');
+const os = require('node:os');
+
+class Locked extends Error {
+	constructor(port) {
+		super(`${port} is locked`);
+	}
+}
+
+const lockedPorts = {
+	old: new Set(),
+	young: new Set(),
+};
+
+// On this interval, the old locked ports are discarded,
+// the young locked ports are moved to old locked ports,
+// and a new young set for locked ports are created.
+const releaseOldLockedPortsIntervalMs = 1000 * 15;
+
+const minPort = 1024;
+const maxPort = 65_535;
+
+// Lazily create interval on first use
+let interval;
+
+const getLocalHosts = () => {
+	const interfaces = os.networkInterfaces();
+
+	// Add undefined value for createServer function to use default host,
+	// and default IPv4 host in case createServer defaults to IPv6.
+	const results = new Set([undefined, '0.0.0.0']);
+
+	for (const _interface of Object.values(interfaces)) {
+		for (const config of _interface) {
+			results.add(config.address);
+		}
+	}
+
+	return results;
+};
+
+const checkAvailablePort = options =>
+	new Promise((resolve, reject) => {
+		const server = net.createServer();
+		server.unref();
+		server.on('error', reject);
+
+		server.listen(options, () => {
+			const {port} = server.address();
+			server.close(() => {
+				resolve(port);
+			});
+		});
+	});
+
+const getAvailablePort = async (options, hosts) => {
+	if (options.host || options.port === 0) {
+		return checkAvailablePort(options);
+	}
+
+	for (const host of hosts) {
+		try {
+			await checkAvailablePort({port: options.port, host}); // eslint-disable-line no-await-in-loop
+		} catch (error) {
+			if (!['EADDRNOTAVAIL', 'EINVAL'].includes(error.code)) {
+				throw error;
+			}
+		}
+	}
+
+	return options.port;
+};
+
+const portCheckSequence = function * (ports) {
+	if (ports) {
+		yield * ports;
+	}
+
+	yield 0; // Fall back to 0 if anything else failed
+};
+
+module.exports = async options => {
+	let ports;
+	let exclude = new Set();
+
+	if (options) {
+		if (options.port) {
+			ports = typeof options.port === 'number' ? [options.port] : options.port;
+		}
+
+		if (options.exclude) {
+			const excludeIterable = options.exclude;
+
+			if (typeof excludeIterable[Symbol.iterator] !== 'function') {
+				throw new TypeError('The `exclude` option must be an iterable.');
+			}
+
+			for (const element of excludeIterable) {
+				if (typeof element !== 'number') {
+					throw new TypeError('Each item in the `exclude` option must be a number corresponding to the port you want excluded.');
+				}
+
+				if (!Number.isSafeInteger(element)) {
+					throw new TypeError(`Number ${element} in the exclude option is not a safe integer and can't be used`);
+				}
+			}
+
+			exclude = new Set(excludeIterable);
+		}
+	}
+
+	if (interval === undefined) {
+		interval = setInterval(() => {
+			lockedPorts.old = lockedPorts.young;
+			lockedPorts.young = new Set();
+		}, releaseOldLockedPortsIntervalMs);
+
+		// Does not exist in some environments (Electron, Jest jsdom env, browser, etc).
+		if (interval.unref) {
+			interval.unref();
+		}
+	}
+
+	const hosts = getLocalHosts();
+
+	for (const port of portCheckSequence(ports)) {
+		try {
+			if (exclude.has(port)) {
+				continue;
+			}
+
+			let availablePort = await getAvailablePort({...options, port}, hosts); // eslint-disable-line no-await-in-loop
+			while (lockedPorts.old.has(availablePort) || lockedPorts.young.has(availablePort)) {
+				if (port !== 0) {
+					throw new Locked(port);
+				}
+
+				availablePort = await getAvailablePort({...options, port}, hosts); // eslint-disable-line no-await-in-loop
+			}
+
+			lockedPorts.young.add(availablePort);
+
+			return availablePort;
+		} catch (error) {
+			if (!['EADDRINUSE', 'EACCES'].includes(error.code) && !(error instanceof Locked)) {
+				throw error;
+			}
+		}
+	}
+
+	throw new Error('No available ports found');
+}
+
+module.exports.portNumbers = (from, to) => {
+	if (!Number.isInteger(from) || !Number.isInteger(to)) {
+		throw new TypeError('`from` and `to` must be integer numbers');
+	}
+
+	if (from < minPort || from > maxPort) {
+		throw new RangeError(`'from' must be between ${minPort} and ${maxPort}`);
+	}
+
+	if (to < minPort || to > maxPort) {
+		throw new RangeError(`'to' must be between ${minPort} and ${maxPort}`);
+	}
+
+	if (from > to) {
+		throw new RangeError('`to` must be greater than or equal to `from`');
+	}
+
+	const generator = function * (from, to) {
+		for (let port = from; port <= to; port++) {
+			yield port;
+		}
+	};
+
+	return generator(from, to);
+}

--- a/vendor/get-port/license
+++ b/vendor/get-port/license
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/get-port/package.json
+++ b/vendor/get-port/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "get-port",
+	"version": "6.1.2",
+	"description": "Get an available port",
+	"license": "MIT",
+	"repository": "sindresorhus/get-port",
+	"funding": "https://github.com/sponsors/sindresorhus",
+	"author": {
+		"name": "Sindre Sorhus",
+		"email": "sindresorhus@gmail.com",
+		"url": "https://sindresorhus.com"
+	},
+	"exports": "./index.js",
+	"engines": {
+		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+	},
+	"scripts": {
+		"test": "xo && ava && tsd"
+	},
+	"files": [
+		"index.js",
+		"index.d.ts"
+	],
+	"keywords": [
+		"port",
+		"find",
+		"finder",
+		"portfinder",
+		"free",
+		"available",
+		"connection",
+		"connect",
+		"open",
+		"net",
+		"tcp",
+		"scan",
+		"random",
+		"preferred",
+		"chosen"
+	],
+	"devDependencies": {
+		"@types/node": "^16.10.2",
+		"ava": "^3.15.0",
+		"tsd": "^0.17.0",
+		"typescript": "^4.4.3",
+		"xo": "^0.45.0"
+	},
+	"sideEffects": false
+}

--- a/vendor/get-port/readme.md
+++ b/vendor/get-port/readme.md
@@ -1,0 +1,117 @@
+# get-port
+
+> Get an available [TCP port](https://en.wikipedia.org/wiki/Port_(computer_networking)).
+
+## Install
+
+```sh
+npm install get-port
+```
+
+## Usage
+
+```js
+import getPort from 'get-port';
+
+console.log(await getPort());
+//=> 51402
+```
+
+Pass in a preferred port:
+
+```js
+import getPort from 'get-port';
+
+console.log(await getPort({port: 3000}));
+// Will use 3000 if available, otherwise fall back to a random port
+```
+
+Pass in an array of preferred ports:
+
+```js
+import getPort from 'get-port';
+
+console.log(await getPort({port: [3000, 3001, 3002]}));
+// Will use any element in the preferred ports array if available, otherwise fall back to a random port
+```
+
+Use the `portNumbers()` helper in case you need a port in a certain range:
+
+```js
+import getPort, {portNumbers} from 'get-port';
+
+console.log(await getPort({port: portNumbers(3000, 3100)}));
+// Will use any port from 3000 to 3100, otherwise fall back to a random port
+```
+
+## API
+
+### getPort(options?)
+
+Returns a `Promise` for a port number.
+
+#### options
+
+Type: `object`
+
+##### port
+
+Type: `number | Iterable<number>`
+
+A preferred port or an iterable of preferred ports to use.
+
+##### exclude
+
+Type: `Iterable<number>`
+
+Ports that should not be returned.
+
+You could, for example, pass it the return value of the `portNumbers()` function.
+
+##### host
+
+Type: `string`
+
+The host on which port resolution should be performed. Can be either an IPv4 or IPv6 address.
+
+By default, it checks availability on all local addresses defined in [OS network interfaces](https://nodejs.org/api/os.html#os_os_networkinterfaces). If this option is set, it will only check the given host.
+
+### portNumbers(from, to)
+
+Generate port numbers in the given range `from`...`to`.
+
+Returns an `Iterable` for port numbers in the given range.
+
+#### from
+
+Type: `number`
+
+The first port of the range. Must be in the range `1024`...`65535`.
+
+#### to
+
+Type: `number`
+
+The last port of the range. Must be in the range `1024`...`65535` and must be greater than `from`.
+
+## Beware
+
+There is a very tiny chance of a race condition if another process starts using the same port number as you in between the time you get the port number and you actually start using it.
+
+Race conditions in the same process are mitigated against by using a lightweight locking mechanism where a port will be held for a minimum of 15 seconds and a maximum of 30 seconds before being released again.
+
+## Related
+
+- [get-port-cli](https://github.com/sindresorhus/get-port-cli) - CLI for this module
+
+---
+
+<div align="center">
+	<b>
+		<a href="https://tidelift.com/subscription/pkg/npm-get-port?utm_source=npm-get-port&utm_medium=referral&utm_campaign=readme">Get professional support for this package with a Tidelift subscription</a>
+	</b>
+	<br>
+	<sub>
+		Tidelift helps make open source sustainable for maintainers while giving companies<br>assurances about security, maintenance, and licensing for their dependencies.
+	</sub>
+</div>


### PR DESCRIPTION
Override cypress' `get-port` library with our own.

The `get-port` lib had to be modified manually due to it being packaged as a `module`, which cypress does not support (at least not the way that Cypress is prepackaged).

The following changes were applied to `get-port`:
- remove type `module` from package.json
- replace `import` statements with `require`
- replace `export` modifiers with `module.exports`

For reference, this is why we're overriding the supplied `get-port` library:
https://github.com/cypress-io/cypress/issues/22997

### For the Curious: Why not just override via NPM?
Because Cypress isn't actually installed completely by NPM. Only the CLI wrapper is. The install script then downloads a prepackaged Cypress binary, which is the main part of the application that contains the `get-port` dependency.