### PR TITLE
Update parsing of cypress version from package-lock

### DIFF
--- a/.github/helpers/generate-release-notes.sh
+++ b/.github/helpers/generate-release-notes.sh
@@ -4,7 +4,7 @@
 CHANGELOG=$(git --no-pager log --no-notes --no-decorate --oneline  v${1}...HEAD)
 
 ## Gather Framework version
-CYPRESS_VER=$(< package-lock.json jq -r '.dependencies["cypress"].version')
+CYPRESS_VER=$(< package-lock.json jq -r '.packages[""].dependencies["cypress"]')
 NODEJS_VER=$(cat .nvmrc | tr -d "v")
 
 ## Generate everything

--- a/.github/helpers/generate-release-notes.sh
+++ b/.github/helpers/generate-release-notes.sh
@@ -4,7 +4,7 @@
 CHANGELOG=$(git --no-pager log --no-notes --no-decorate --oneline  v${1}...HEAD)
 
 ## Gather Framework version
-CYPRESS_VER=$(< package-lock.json jq -r '.packages[""].dependencies["cypress"]')
+CYPRESS_VER=$(npm list cypress --json --package-lock-only | jq --raw-output '.dependencies["cypress"].version')
 NODEJS_VER=$(cat .nvmrc | tr -d "v")
 
 ## Generate everything


### PR DESCRIPTION
The "dependencies" object is actually obsolete, but remains for backwards compatibility. Read the cypress version from the "packages" object.