### PR TITLE
feat: Opt in only for multi reporter configuration

### DIFF
--- a/src/cypress-runner.ts
+++ b/src/cypress-runner.ts
@@ -186,7 +186,7 @@ function getCypressOpts(
   if (runCfg.cypress.reporters && runCfg.cypress.reporters.length > 0) {
     opts = configureReporters(runCfg, opts);
     console.log(
-      'Configuring reporters with saucectl is deprecated and will be removed in a future release. Migrate your configuration to your cypress config file.',
+      'Configuring cypress reporters with saucectl is deprecated and will be removed in a future release. Migrate your configuration to your cypress config file.',
     );
   }
   configureWebkitOptions(process.env, opts, suite);

--- a/src/cypress-runner.ts
+++ b/src/cypress-runner.ts
@@ -185,6 +185,7 @@ function getCypressOpts(
 
   if (runCfg.cypress.reporters) {
     opts = configureReporters(runCfg, opts);
+    console.log('Configuring multi reporters with saucectl is deprecated. We recommend migrating your configuration to your cypress config file.');
   }
   configureWebkitOptions(process.env, opts, suite);
 

--- a/src/cypress-runner.ts
+++ b/src/cypress-runner.ts
@@ -186,7 +186,7 @@ function getCypressOpts(
   if (runCfg.cypress.reporters) {
     opts = configureReporters(runCfg, opts);
     console.log(
-      'Configuring multi reporters with saucectl is deprecated. We recommend migrating your configuration to your cypress config file.',
+      'Configuring multi reporters with saucectl is deprecated and will be removed in a future release. Migrate your configuration to your cypress config file.',
     );
   }
   configureWebkitOptions(process.env, opts, suite);

--- a/src/cypress-runner.ts
+++ b/src/cypress-runner.ts
@@ -185,7 +185,9 @@ function getCypressOpts(
 
   if (runCfg.cypress.reporters) {
     opts = configureReporters(runCfg, opts);
-    console.log('Configuring multi reporters with saucectl is deprecated. We recommend migrating your configuration to your cypress config file.');
+    console.log(
+      'Configuring multi reporters with saucectl is deprecated. We recommend migrating your configuration to your cypress config file.',
+    );
   }
   configureWebkitOptions(process.env, opts, suite);
 

--- a/src/cypress-runner.ts
+++ b/src/cypress-runner.ts
@@ -186,7 +186,7 @@ function getCypressOpts(
   if (runCfg.cypress.reporters && runCfg.cypress.reporters.length > 0) {
     opts = configureReporters(runCfg, opts);
     console.log(
-      'Configuring multi reporters with saucectl is deprecated and will be removed in a future release. Migrate your configuration to your cypress config file.',
+      'Configuring reporters with saucectl is deprecated and will be removed in a future release. Migrate your configuration to your cypress config file.',
     );
   }
   configureWebkitOptions(process.env, opts, suite);

--- a/src/cypress-runner.ts
+++ b/src/cypress-runner.ts
@@ -183,7 +183,7 @@ function getCypressOpts(
     opts.key = runCfg.cypress.key;
   }
 
-  if (runCfg.cypress.reporters) {
+  if (runCfg.cypress.reporters && runCfg.cypress.reporters.length > 0) {
     opts = configureReporters(runCfg, opts);
     console.log(
       'Configuring multi reporters with saucectl is deprecated and will be removed in a future release. Migrate your configuration to your cypress config file.',

--- a/src/cypress-runner.ts
+++ b/src/cypress-runner.ts
@@ -183,7 +183,9 @@ function getCypressOpts(
     opts.key = runCfg.cypress.key;
   }
 
-  opts = configureReporters(runCfg, opts);
+  if (runCfg.cypress.reporters) {
+    opts = configureReporters(runCfg, opts);
+  }
   configureWebkitOptions(process.env, opts, suite);
 
   return opts as CypressCommandLine.CypressRunOptions;


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Only run the runner's multi reporter configuration if user has opted in via their saucectl config. This allows the user to simply configure their preferred reporting setup in their cypress config file.

[DEVX-2914]


[DEVX-2914]: https://saucedev.atlassian.net/browse/DEVX-2914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ