### PR TITLE
feat: enable use of global node context

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,6 @@ jobs:
       - name: Install Webkit Dependencies
         run: npx playwright install-deps webkit
 
-      - name: Get NPM path
-        run: echo "NPM_CLI_PATH=`which npm | sed 's/bin\/npm/lib\/node_modules\/npm\/bin\/npm-cli.js/'`" >> $GITHUB_ENV
-
       - name: Integration Tests
         env:
           SAUCE_CYPRESS_VIDEO_RECORDING: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "lodash": "4.17.21",
         "mkdirp": "^3.0.1",
         "playwright-webkit": "1.45.2",
-        "sauce-testrunner-utils": "3.0.0",
+        "sauce-testrunner-utils": "3.1.0",
         "typescript": "5.5.3",
         "webpack": "5.93.0",
         "xml-js": "^1.6.11",
@@ -8204,6 +8204,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -14292,9 +14293,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sauce-testrunner-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sauce-testrunner-utils/-/sauce-testrunner-utils-3.0.0.tgz",
-      "integrity": "sha512-0W7UuxJ/kOHlDdvFNUnv/HMIp9N8jNHVELkTxwDMZuEXP7EvRSkskaEblmqwCgU/3UxpjgpRxuhxKEj+mbOArA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/sauce-testrunner-utils/-/sauce-testrunner-utils-3.1.0.tgz",
+      "integrity": "sha512-jaDK1XxIq8A3peFjxkR6kXkQrmsa7SeVw5h/+qcpFX2PUvuXNv06PabqXvhD3JAG1SAqC6t6DIb/3Djz3OmLDQ==",
       "dependencies": {
         "lodash": "^4.17.21",
         "npm": "^10.8.1",
@@ -15015,7 +15016,8 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -15915,6 +15917,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lodash": "4.17.21",
     "mkdirp": "^3.0.1",
     "playwright-webkit": "1.45.2",
-    "sauce-testrunner-utils": "3.0.0",
+    "sauce-testrunner-utils": "3.1.0",
     "typescript": "5.5.3",
     "webpack": "5.93.0",
     "xml-js": "^1.6.11",

--- a/src/cypress-runner.ts
+++ b/src/cypress-runner.ts
@@ -18,6 +18,7 @@ import { createJUnitReport } from '@saucelabs/cypress-junit-plugin';
 import { clearTimeout, setTimeout } from 'timers';
 
 import { RunConfig, Suite } from './types';
+import { NodeContext } from 'sauce-testrunner-utils/lib/types';
 
 async function report(
   results:
@@ -271,7 +272,11 @@ async function cypressRunner(
       'bin',
       'npm-cli.js',
     );
-  const nodeCtx = { nodePath: nodeBin, npmPath: npmBin };
+  const nodeCtx: NodeContext = {
+    nodePath: nodeBin,
+    npmPath: npmBin,
+    useGlobals: !!runCfg.nodeVersion,
+  };
 
   await prepareNpmEnv(runCfg, nodeCtx);
   const cypressOpts = getCypressOpts(runCfg, suiteName);

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export type RunConfig = {
   resultsDir: string;
   path: string;
   cypress: CypressConfig;
+  nodeVersion?: string;
 } & NpmConfigContainer &
   PathContainer &
   ResultPathContainer &

--- a/tests/integration/config-tests/sauce-runner.json
+++ b/tests/integration/config-tests/sauce-runner.json
@@ -1,4 +1,5 @@
 {
+    "nodeVersion": "20",
     "cypress": {
         "configFile": "cypress.config.ts"
     },

--- a/tests/integration/env-tests/sauce-runner.json
+++ b/tests/integration/env-tests/sauce-runner.json
@@ -1,4 +1,5 @@
 {
+  "nodeVersion": "20",
   "cypress": {
     "configFile": "cypress.config.js"
   },


### PR DESCRIPTION
## Description

Allow the runner to determine the proper node context: bundled vs. globally installed.

The context affects how we interact with `npm`.