### PR TITLE
ci: Support consecutive pre releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,17 +61,35 @@ jobs:
         if: ${{ steps.prep.outputs.tag_name == '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ -z "${{ github.event.inputs.releaseType }}" ] && [ -z "${{ github.event.inputs.preReleaseFlavor }}" ];then
             echo "No release type provided."
             exit 1
           fi
 
+          RELEASE_TYPE="${{ github.event.inputs.releaseType }}"
+
           if [ -n "${{ github.event.inputs.preReleaseFlavor }}" ];then
-            PRE_RELEASE_ARGS="--preRelease=${{ github.event.inputs.preReleaseFlavor }} --github.preRelease"
+            LATEST_TAG=$(gh release list --limit 1 --json tagName --jq '.[] | .tagName')
+            # NOTE: Expected tag format is {VERSION}-{FLAVOR}.{FLAVOR_VERSION}
+            LATEST_FLAVOR=$(echo ${LATEST_TAG} | awk -F'-' '{ print $2 }' | awk -F'.' '{ print $1 }')
+
+            echo "Latest tag: ${LATEST_TAG}"
+            echo "Latest flavor: ${LATEST_FLAVOR}"
+
+            if [ "${LATEST_FLAVOR}" == "${{ github.event.inputs.preReleaseFlavor}}" ];then
+              # NOTE: If the inputted pre-release flavor matches the current pre-release flavor, we only
+              # want to increment the pre-release version instead of a full version bump.
+              PRE_RELEASE_ARGS="--preRelease"
+              RELEASE_TYPE=""
+            else
+              PRE_RELEASE_ARGS="--preRelease=${{ github.event.inputs.preReleaseFlavor }} --github.preRelease"
+            fi
           fi
 
-          npx release-it ${{ github.event.inputs.releaseType }} ${PRE_RELEASE_ARGS}
+          npx release-it ${RELEASE_TYPE} ${PRE_RELEASE_ARGS}
+
 
   release-windows-bundle:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,6 @@ jobs:
             # NOTE: Expected tag format is {VERSION}-{FLAVOR}.{FLAVOR_VERSION}
             LATEST_FLAVOR=$(echo ${LATEST_TAG} | awk -F'-' '{ print $2 }' | awk -F'.' '{ print $1 }')
 
-            echo "Latest tag: ${LATEST_TAG}"
-            echo "Latest flavor: ${LATEST_FLAVOR}"
-
             if [ "${LATEST_FLAVOR}" == "${{ github.event.inputs.preReleaseFlavor}}" ];then
               # NOTE: If the inputted pre-release flavor matches the current pre-release flavor, we only
               # want to increment the pre-release version instead of a full version bump.


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Consecutive pre-releases are not currently possible. Running two release pipelines with the same pre release flavor would result in the following releases: `1.0.1-rc.0` and `1.0.2-rc.0`. But what we want when we run the second pre-release pipeline is `1.0.1-rc.1`.

Now, parse the latest release name and if the latest is a pre-release and its flavor matches the inputted flavor, we only increment the pre-release version as opposed to a full version bump.

[DEVX-3004]


[DEVX-3004]: https://saucedev.atlassian.net/browse/DEVX-3004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ