### PR TITLE
ci: unpin saucectl version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,7 +292,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           skip-run: true
-          saucectl-version: v0.184.1
 
       - name: Parse Release Version
         id: parse_version
@@ -324,7 +323,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           skip-run: true
-          saucectl-version: v0.184.1
 
       - name: Parse Release Version
         id: parse_version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,7 +191,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           skip-run: true
-          saucectl-version: v0.184.1
 
       - name: Test on Sauce
         working-directory: ./tests/cloud/
@@ -239,7 +238,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           skip-run: true
-          saucectl-version: v0.184.1
 
       - name: Run web-page
         run: |
@@ -287,7 +285,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           skip-run: true
-          saucectl-version: v0.184.1
 
       - name: Test on Sauce
         working-directory: ./tests/integration/${{ matrix.type }}-project/


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

With the fix https://github.com/saucelabs/saucectl/pull/955, we can unpin saucectl version.