### PR TITLE
fix: set explicit rootDir in tsconfig.json to fix TS5011 under TS 6.x

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules"],
   "compilerOptions": {
+    "rootDir": "./src",
     "outDir": "./lib",
     "strict": false
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib",
+    "types": ["node"],
     "strict": false
   }
 }


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
TypeScript 6.0 promotes the previously-inferred common source directory into a hard error (TS5011) when outDir is set without an explicit rootDir. Spell out rootDir: ./src so the build keeps working under both TS 5.9 (current) and TS 6.x (incoming via monthly dependency update).
