### PR TITLE
Add an Apple Silicon bundle for macOS 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,9 +231,74 @@ jobs:
         run: |
           gh release upload ${{ steps.prep.outputs.version }} cypress-macos-amd64.zip
 
+  release-macos-arm-bundle:
+    # macos-latest is Apple Silicon arm64 for macOS 14
+    runs-on: macos-latest
+    needs: [create-release-draft]
+    steps:
+      - name: Find Matching Draft Tag
+        # Fetches the `asset_id` of the uploaded bundle. A non-empty `asset_id` signals a successful upload, preventing duplicate uploads in retry attempts.
+        id: prep
+        run: |
+          VERSION=$(curl -s -H "Authorization: token ${{ github.token }}" \
+                      https://api.github.com/repos/${{ github.repository }}/releases | \
+                      jq -r "[.[] | select(.draft == true) | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .tag_name")
+          RELEASE_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
+                      https://api.github.com/repos/${{ github.repository }}/releases | \
+                      jq -r "[.[] | select(.draft == true) | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .id")
+
+          if [ "${VERSION}" = "" ];then
+              echo "No draft version found"
+              exit 1
+          fi
+
+          ASSET_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
+                      https://api.github.com/repos/${{ github.repository }}/releases | \
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .assets | .[] | select(.name == \"cypress-macos-arm64.zip\") | .id | select(. != null)")
+
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "release_id=${RELEASE_ID}" >> $GITHUB_OUTPUT
+          echo "asset_id=${ASSET_ID}" >> $GITHUB_OUTPUT
+
+      - run: echo "${{ steps.prep.outputs.release_id }} - ${{ steps.prep.outputs.version }} - ${{ steps.prep.outputs.asset_id }}"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: ${{ steps.prep.outputs.asset_id == '' }}
+        with:
+          ref: ${{ steps.prep.outputs.version }}
+
+      - name: Setup Node
+        if: ${{ steps.prep.outputs.asset_id == '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Update Release Version
+        if: ${{ steps.prep.outputs.asset_id == '' }}
+        run: |
+          npm version --no-git-tag-version ${{  steps.prep.outputs.version }}
+
+      - name: Bundle Directory
+        if: ${{ steps.prep.outputs.asset_id == '' }}
+        run: bash ./scripts/bundle.macos.sh
+
+      - name: List Bundle Contents
+        if: ${{ steps.prep.outputs.asset_id == '' }}
+        run: ls -R bundle/
+
+      - name: Upload Release Asset
+        if: ${{ steps.prep.outputs.asset_id == '' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload ${{ steps.prep.outputs.version }} cypress-macos-arm64.zip
+
   publish-release:
     runs-on: ubuntu-latest
-    needs: [release-windows-bundle, release-macos-bundle]
+    needs: [release-windows-bundle, release-macos-bundle, release-macos-arm-bundle]
     steps:
       - name: Find Matching Draft Tag
         id: prep

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,13 +155,59 @@ jobs:
         run: |
           gsutil cp ./cypress-macos-amd64.zip gs://${{ secrets.GCS_RUNNER_BUCKET }}/cypress-macos-amd64-${{ github.run_id }}.zip
 
+  build-mac-arm-bundle:
+    # macos-latest is Apple Silicon arm64 for macOS 14
+    runs-on: macos-latest
+    needs: [lint, integration]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Google Cloud Login
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.GCS_RUNNER_SA_KEY }}'
+
+      - name: Install gcloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCS_RUNNER_PROJECT_ID }}
+        env:
+          CLOUDSDK_PYTHON: ${{env.pythonLocation}}/python
+
+      - name: Update Release Version
+        run: npm version --no-git-tag-version 1.0.0
+
+      - name: Bundle Directory
+        run: bash ./scripts/bundle.macos.sh
+
+      - name: Get Cypress Version
+        run: |
+          CYPRESS_VERSION=$(< package-lock.json jq -r '.dependencies["cypress"].version')
+          echo "cypress_version=$CYPRESS_VERSION" >> $GITHUB_ENV
+
+      - name: Upload to GCS
+        run: |
+          gsutil cp ./cypress-macos-arm64.zip gs://${{ secrets.GCS_RUNNER_BUCKET }}/cypress-macos-arm64-${{ github.run_id }}.zip
+
   bundle-test:
-    needs: [build-windows-bundle, build-mac-bundle]
+    needs: [build-windows-bundle, build-mac-bundle, build-mac-arm-bundle]
     strategy:
       max-parallel: 3
       fail-fast: false
       matrix:
-        os: [Win10, Win11, macOS11, macOS12, macOS13]
+        os: [Win10, Win11, macOS11, macOS12, macOS13, macOS14]
         browser: [Chrome, Firefox, Webkit]
         exclude:
           - os: Win10
@@ -191,6 +237,10 @@ jobs:
           BUNDLE_URL=https://storage.googleapis.com/${{ secrets.GCS_RUNNER_BUCKET }}/cypress-windows-amd64-${{ github.run_id }}.zip
           if [[ ${{ matrix.os }} =~ ^mac ]];then
             BUNDLE_URL=https://storage.googleapis.com/${{ secrets.GCS_RUNNER_BUCKET }}/cypress-macos-amd64-${{ github.run_id }}.zip
+          fi
+          # macOS 14 uses the arm64 bundle
+          if [[ "${{ matrix.os }}" == "macOS14" ]];then
+            BUNDLE_URL=https://storage.googleapis.com/${{ secrets.GCS_RUNNER_BUCKET }}/cypress-macos-arm64-${{ github.run_id }}.zip
           fi
 
           saucectl run \

--- a/scripts/bundle.macos.sh
+++ b/scripts/bundle.macos.sh
@@ -8,8 +8,17 @@ bash ./scripts/bundle.sh
 export PLAYWRIGHT_BROWSERS_PATH=0
 export PLAYWRIGHT_SKIP_BROWSER_GC=1
 cd bundle
-PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=mac13 npx playwright install webkit
+
+if [ "$(uname -m)" = "arm64" ]; then
+  # Apple Silicon runner installs arm64 WebKit for macOS 14
+  PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=mac14-arm64 npx playwright install webkit
+  ZIP_NAME=cypress-macos-arm64.zip
+else
+  # Intel runner installs amd64 WebKit
+  PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=mac13 npx playwright install webkit
+  ZIP_NAME=cypress-macos-amd64.zip
+fi
 cd ..
 
 # Archive Bundle with symlinks
-zip --symlinks -r cypress-macos-amd64.zip bundle/
+zip --symlinks -r "${ZIP_NAME}" bundle/

--- a/tests/cloud/.sauce/config.yml
+++ b/tests/cloud/.sauce/config.yml
@@ -115,6 +115,26 @@ suites:
       testingType: "e2e"
       specPattern: [ "cypress/e2e/no-sc/**/*.cy.js" ]
 
+  # macOS 14 tests on Apple Silicon
+  - name: "Cypress - macOS14 - Chrome"
+    browser: "chrome"
+    platformName: "macOS 14"
+    config:
+      testingType: "e2e"
+      specPattern: [ "cypress/e2e/no-sc/**/*.cy.js" ]
+  - name: "Cypress - macOS14 - Firefox"
+    browser: "firefox"
+    platformName: "macOS 14"
+    config:
+      testingType: "e2e"
+      specPattern: [ "cypress/e2e/no-sc/**/*.cy.js" ]
+  - name: "Cypress - macOS14 - Webkit"
+    browser: "webkit"
+    platformName: "macOS 14"
+    config:
+      testingType: "e2e"
+      specPattern: [ "cypress/e2e/no-sc/**/*.cy.js" ]
+
 notifications:
   slack:
     channels: ["devx-slack-notifications"]


### PR DESCRIPTION
What this does

This adds a separate arm64 cypress bundle for Apple Silicon. The build script installs the arm64 webkit when it runs on an Apple Silicon machine and names the zip for arm64. The release and test workflows build and upload this bundle and run the macOS 14 suites.

Why

This is part of INT-246 to run cypress on Apple Silicon macOS. Merging this and running a release produces sauce cypress runner version 14.1.0 which the side disk will install.

The macOS 14 bundle test in this PR runs real cloud jobs and will fail until the saucectl schema PR 1088 is merged and test composer and image metadata service are live on the test environment. Keep this as a draft until those are in place. Merging this publishes release 14.1.0.
