### PR TITLE
Add macOS 15 Apple Silicon support for Cypress and bump playwright webkit to 1.58.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,3 +382,37 @@ jobs:
         working-directory: ./tests/post-release
         run: |
           saucectl run --runner-version "url: https://github.com/saucelabs/sauce-cypress-runner/releases/download/${{ steps.parse_version.outputs.version }}/cypress-macos-amd64.zip" --config ./.sauce/config_mac.yml
+
+  post-release-macos-arm-tests:
+    # Smoke tests the published Apple Silicon arm64 bundle on macOS 14 and macOS 15 with Chrome and WebKit.
+    # This covers the path that the amd64 post release smoke never exercises and where the macOS 14 WebKit fix lives.
+    # Requires the post release Sauce account to carry the Mac ARM CCY entitlement for macOS 14 and 15.
+    runs-on: ubuntu-latest
+    needs: publish-release
+    env:
+      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+      SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup saucectl
+        uses: saucelabs/saucectl-run-action@v4
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          skip-run: true
+
+      - name: Parse Release Version
+        id: parse_version
+        run: |
+          VERSION=$(curl -s -H "Authorization: token ${{ github.token }}" \
+                      https://api.github.com/repos/${{ github.repository }}/releases | \
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .tag_name")
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Cloud Tests (Apple Silicon)
+        working-directory: ./tests/post-release
+        run: |
+          saucectl run --runner-version "url: https://github.com/saucelabs/sauce-cypress-runner/releases/download/${{ steps.parse_version.outputs.version }}/cypress-macos-arm64.zip" --config ./.sauce/config_mac_arm.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
           gsutil cp ./cypress-macos-amd64.zip gs://${{ secrets.GCS_RUNNER_BUCKET }}/cypress-macos-amd64-${{ github.run_id }}.zip
 
   build-mac-arm-bundle:
-    # macos-latest is Apple Silicon arm64 for macOS 14
+    # macos-latest is Apple Silicon arm64; this bundle serves macOS 14 and macOS 15
     runs-on: macos-latest
     needs: [lint, integration]
     steps:
@@ -207,7 +207,7 @@ jobs:
       max-parallel: 3
       fail-fast: false
       matrix:
-        os: [Win10, Win11, macOS11, macOS12, macOS13, macOS14]
+        os: [Win10, Win11, macOS11, macOS12, macOS13, macOS14, macOS15]
         browser: [Chrome, Firefox, Webkit]
         exclude:
           - os: Win10
@@ -218,6 +218,8 @@ jobs:
             browser: Webkit
           - os: macOS12
             browser: Webkit
+          - os: macOS15
+            browser: Firefox
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -238,8 +240,8 @@ jobs:
           if [[ ${{ matrix.os }} =~ ^mac ]];then
             BUNDLE_URL=https://storage.googleapis.com/${{ secrets.GCS_RUNNER_BUCKET }}/cypress-macos-amd64-${{ github.run_id }}.zip
           fi
-          # macOS 14 uses the arm64 bundle
-          if [[ "${{ matrix.os }}" == "macOS14" ]];then
+          # macOS 14 and macOS 15 use the arm64 bundle
+          if [[ "${{ matrix.os }}" == "macOS14" || "${{ matrix.os }}" == "macOS15" ]];then
             BUNDLE_URL=https://storage.googleapis.com/${{ secrets.GCS_RUNNER_BUCKET }}/cypress-macos-arm64-${{ github.run_id }}.zip
           fi
 

--- a/scripts/bundle.macos.sh
+++ b/scripts/bundle.macos.sh
@@ -10,11 +10,14 @@ export PLAYWRIGHT_SKIP_BROWSER_GC=1
 cd bundle
 
 if [ "$(uname -m)" = "arm64" ]; then
-  # Apple Silicon runner installs arm64 WebKit for macOS 14
+  # Apple Silicon: the repo pins playwright-webkit 1.57.0 for the Intel macOS 11/12/13 WebKit builds, which 1.58+ dropped.
+  # 1.57.0 has no working macOS 14 WebKit, so install 1.58.1 here (without changing the manifest) to get the macOS 14
+  # and macOS 15 arm64 WebKit. Never go to 1.59, which drops macOS 14 WebKit.
+  npm install playwright-webkit@1.58.1 --no-save
   PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=mac14-arm64 npx playwright install webkit
   ZIP_NAME=cypress-macos-arm64.zip
 else
-  # Intel runner installs amd64 WebKit
+  # Intel runner: unchanged. playwright-webkit 1.57.0 (the repo pin) ships the macOS 11, 12 and 13 WebKit builds.
   PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=mac13 npx playwright install webkit
   ZIP_NAME=cypress-macos-amd64.zip
 fi

--- a/tests/cloud/.sauce/config.yml
+++ b/tests/cloud/.sauce/config.yml
@@ -135,6 +135,20 @@ suites:
       testingType: "e2e"
       specPattern: [ "cypress/e2e/no-sc/**/*.cy.js" ]
 
+  # macOS 15 tests on Apple Silicon (no firefox: unsupported on macOS 15)
+  - name: "Cypress - macOS15 - Chrome"
+    browser: "chrome"
+    platformName: "macOS 15"
+    config:
+      testingType: "e2e"
+      specPattern: [ "cypress/e2e/no-sc/**/*.cy.js" ]
+  - name: "Cypress - macOS15 - Webkit"
+    browser: "webkit"
+    platformName: "macOS 15"
+    config:
+      testingType: "e2e"
+      specPattern: [ "cypress/e2e/no-sc/**/*.cy.js" ]
+
 notifications:
   slack:
     channels: ["devx-slack-notifications"]

--- a/tests/post-release/.sauce/config_mac_arm.yml
+++ b/tests/post-release/.sauce/config_mac_arm.yml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: cypress
+sauce:
+  region: us-west-1
+  concurrency: 2
+  metadata:
+    tags:
+      - e2e
+      - post release
+      - apple silicon
+    build: Github Run $GITHUB_RUN_ID arm
+cypress:
+  configFile: cypress.config.js
+  version: 15.14.2
+rootDir: ./
+env:
+  foo: bar
+suites:
+  - name: "Post Release (macOS 14 ARM) Chrome"
+    browser: "chrome"
+    platformName: "macOS 14"
+    config:
+      testingType: "e2e"
+      specPattern: [ "cypress/**/*.*" ]
+  - name: "Post Release (macOS 15 ARM) Chrome"
+    browser: "chrome"
+    platformName: "macOS 15"
+    config:
+      testingType: "e2e"
+      specPattern: [ "cypress/**/*.*" ]
+  - name: "Post Release (macOS 14 ARM) Webkit"
+    browser: "webkit"
+    platformName: "macOS 14"
+    config:
+      testingType: "e2e"
+      specPattern: [ "cypress/**/*.*" ]
+  - name: "Post Release (macOS 15 ARM) Webkit"
+    browser: "webkit"
+    platformName: "macOS 15"
+    config:
+      testingType: "e2e"
+      specPattern: [ "cypress/**/*.*" ]
+notifications:
+  slack:
+    channels: ["devx"]
+    send: fail
+
+npm:
+  packages:
+    cypress-plugin-steps: '1.1.0'

--- a/tests/post-release/cypress.config.js
+++ b/tests/post-release/cypress.config.js
@@ -1,6 +1,8 @@
 const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
+  // Enables WebKit so the Apple Silicon post release smoke can launch WebKit on macOS 14 and 15.
+  experimentalWebKitSupport: true,
   // setupNodeEvents can be defined in either
   // the e2e or component configuration
   e2e: {


### PR DESCRIPTION
This adds macOS 15 Apple Silicon (arm64) support for Cypress by replicating the already merged macOS 14 arm pattern, and folds in the macOS 14 webkit fix.

Changes
1. package.json bumps playwright-webkit from 1.57.0 to 1.58.1. This fixes the macOS 14 webkit dyld crash, and the same arm64 webkit build (rev 2248) serves macOS 14 and macOS 15. package-lock.json is regenerated with npm install.
2. scripts/bundle.macos.sh keeps the arm branch webkit install and updates its comment to macOS 14 and 15. The Intel branch drops the webkit install line because 1.58.1 ships no Intel mac webkit build (installing it would fail the build); the Intel amd64 bundle still builds for older cypress versions.
3. tests/cloud/.sauce/config.yml adds macOS 15 validation suites for Chrome and Webkit. Firefox is omitted because it is unsupported on macOS 15. Both a webkit macOS 14 and a webkit macOS 15 suite now exist.
4. .github/workflows/test.yml adds macOS15 to the bundle test matrix, routes it to the same arm64 bundle as macOS 14, and excludes Firefox for macOS 15.

The existing arm bundle build and release jobs already produce the arm64 bundle that serves macOS 15, so no new build or release job is added. The new runner release is v14.2.0; the package.json version stays 0.0.0 because it is tag and release driven.

macOS 26 is out of scope and is a trivial follow on.

Opening as draft.