### PR TITLE
ci: migrate Sauce Connect action to v3 (Sauce Connect 5)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -290,11 +290,12 @@ jobs:
         working-directory: ./tests/cloud/www/
 
       - name: Start sauce-connect
-        uses: saucelabs/sauce-connect-action@v2
+        uses: saucelabs/sauce-connect-action@v3
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-          tunnelIdentifier: github-cypress-sc-check-tunnel-${{ matrix.os }}-${{ matrix.browser }}
+          region: us-west
+          tunnelName: github-cypress-sc-check-tunnel-${{ matrix.os }}-${{ matrix.browser }}
 
       - name: Test on Sauce (+ Sauce-Connect)
         working-directory: ./tests/cloud/


### PR DESCRIPTION
## What

Bump `saucelabs/sauce-connect-action` from v2 to v3 in the `bundle-tests-with-sc` job. v3 requires `region` and renames `tunnelIdentifier` to `tunnelName`.

## Why

Sauce Labs stopped accepting Sauce Connect 4 traffic on 31 July 2026. The v2 action runs SC 4.9.2, so the tunnel is refused (`Tunnel shutdown reason: 'remote shutdown'`) and all 11 `bundle-tests-with-sc` jobs time out. Seen on #363.

The test step already passes `--tunnel-name` to saucectl, so no change is needed there.